### PR TITLE
Implement basic memory features

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -1,1 +1,3 @@
 # Default configuration
+memory:
+  working_size: 10

--- a/core/emotion_model.py
+++ b/core/emotion_model.py
@@ -1,1 +1,21 @@
-# Emotion analysis
+"""Very small rule-based emotion analyzer."""
+
+from __future__ import annotations
+
+from typing import List
+
+POSITIVE = {"happy", "joy", "love", "great", "awesome", "good"}
+NEGATIVE = {"sad", "angry", "bad", "terrible", "awful"}
+
+
+def analyze_emotions(text: str) -> List[str]:
+    """Return a list of detected emotion labels."""
+    words = set(text.lower().split())
+    emotions: List[str] = []
+    if words & POSITIVE:
+        emotions.append("positive")
+    if words & NEGATIVE:
+        emotions.append("negative")
+    if not emotions:
+        emotions.append("neutral")
+    return emotions

--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -1,28 +1,30 @@
 """Manage creation and storage of memories."""
 
+from __future__ import annotations
+
 from typing import Iterable, List
 
 from core.memory_entry import MemoryEntry
-from encoding.encoder import encode_text
+from core.memory_types.episodic import EpisodicMemory
+from core.memory_types.semantic import SemanticMemory
+from core.memory_types.procedural import ProceduralMemory
+from core.working_memory import WorkingMemory
 
 
 class MemoryManager:
-    """In-memory implementation of the memory store."""
+    """Coordinator for different memory systems."""
 
     def __init__(self) -> None:
-        self._entries: List[MemoryEntry] = []
+        self.episodic = EpisodicMemory()
+        self.semantic = SemanticMemory()
+        self.procedural = ProceduralMemory()
+        self.working = WorkingMemory()
 
     def add(self, content: str, *, emotions: Iterable[str] | None = None, metadata: dict | None = None) -> MemoryEntry:
-        """Create and store a new :class:`MemoryEntry`."""
-        entry = MemoryEntry(
-            content=content,
-            embedding=encode_text(content),
-            emotions=list(emotions or []),
-            metadata=metadata or {},
-        )
-        self._entries.append(entry)
+        """Add content to episodic memory and update working memory."""
+        entry = self.episodic.add(content, emotions=emotions, metadata=metadata)
+        self.working.load(self.episodic.all())
         return entry
 
     def all(self) -> List[MemoryEntry]:
-        """Return list of all stored memories."""
-        return list(self._entries)
+        return self.episodic.all()

--- a/core/memory_types/episodic.py
+++ b/core/memory_types/episodic.py
@@ -1,1 +1,28 @@
-# Episodic memory
+"""Episodic memory store."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from core.memory_entry import MemoryEntry
+from encoding.encoder import encode_text
+
+
+class EpisodicMemory:
+    """Simple list-based episodic memory."""
+
+    def __init__(self) -> None:
+        self._entries: List[MemoryEntry] = []
+
+    def add(self, content: str, *, emotions: Iterable[str] | None = None, metadata: dict | None = None) -> MemoryEntry:
+        entry = MemoryEntry(
+            content=content,
+            embedding=encode_text(content),
+            emotions=list(emotions or []),
+            metadata=metadata or {},
+        )
+        self._entries.append(entry)
+        return entry
+
+    def all(self) -> List[MemoryEntry]:
+        return list(self._entries)

--- a/core/memory_types/procedural.py
+++ b/core/memory_types/procedural.py
@@ -1,1 +1,28 @@
-# Procedural memory
+"""Procedural memory store."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from core.memory_entry import MemoryEntry
+from encoding.encoder import encode_text
+
+
+class ProceduralMemory:
+    """Skills and procedures."""
+
+    def __init__(self) -> None:
+        self._entries: List[MemoryEntry] = []
+
+    def add(self, content: str, *, emotions: Iterable[str] | None = None, metadata: dict | None = None) -> MemoryEntry:
+        entry = MemoryEntry(
+            content=content,
+            embedding=encode_text(content),
+            emotions=list(emotions or []),
+            metadata=metadata or {},
+        )
+        self._entries.append(entry)
+        return entry
+
+    def all(self) -> List[MemoryEntry]:
+        return list(self._entries)

--- a/core/memory_types/semantic.py
+++ b/core/memory_types/semantic.py
@@ -1,1 +1,28 @@
-# Semantic memory
+"""Semantic memory store."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from core.memory_entry import MemoryEntry
+from encoding.encoder import encode_text
+
+
+class SemanticMemory:
+    """Knowledge about facts and concepts."""
+
+    def __init__(self) -> None:
+        self._entries: List[MemoryEntry] = []
+
+    def add(self, content: str, *, emotions: Iterable[str] | None = None, metadata: dict | None = None) -> MemoryEntry:
+        entry = MemoryEntry(
+            content=content,
+            embedding=encode_text(content),
+            emotions=list(emotions or []),
+            metadata=metadata or {},
+        )
+        self._entries.append(entry)
+        return entry
+
+    def all(self) -> List[MemoryEntry]:
+        return list(self._entries)

--- a/core/working_memory.py
+++ b/core/working_memory.py
@@ -1,1 +1,21 @@
-# Working memory
+"""Short-term working memory manager."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from core.memory_entry import MemoryEntry
+
+
+class WorkingMemory:
+    """Maintain a limited-size list of active memories."""
+
+    def __init__(self, max_size: int = 10) -> None:
+        self.max_size = max_size
+        self._entries: List[MemoryEntry] = []
+
+    def load(self, memories: Iterable[MemoryEntry]) -> None:
+        self._entries = list(memories)[-self.max_size :]
+
+    def contents(self) -> List[MemoryEntry]:
+        return list(self._entries)

--- a/dreaming/dream_engine.py
+++ b/dreaming/dream_engine.py
@@ -1,1 +1,16 @@
-# Dreaming engine
+"""Background dreaming process for summarizing episodic memory."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from core.memory_entry import MemoryEntry
+from ms_utils import format_context
+
+
+class DreamEngine:
+    """Generate dream summaries from episodic memories."""
+
+    def summarize(self, memories: Iterable[MemoryEntry]) -> str:
+        lines = [m.content for m in memories]
+        return "Dream:" + " " + format_context(lines)

--- a/llm/llm_router.py
+++ b/llm/llm_router.py
@@ -1,1 +1,13 @@
-# Factory for LLM selection
+"""Simple LLM router selecting between available backends."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from llm.local_llm import LocalLLM
+
+
+def get_llm(name: Literal["local"] = "local") -> LocalLLM:
+    if name == "local":
+        return LocalLLM()
+    raise ValueError(f"Unknown LLM: {name}")

--- a/llm/local_llm.py
+++ b/llm/local_llm.py
@@ -1,1 +1,5 @@
-# Local model interface
+"""Extremely small local LLM stub."""
+
+class LocalLLM:
+    def generate(self, prompt: str) -> str:
+        return f"Echo: {prompt}"

--- a/reconstruction/reconstructor.py
+++ b/reconstruction/reconstructor.py
@@ -1,5 +1,7 @@
 """Reconstruct working memory context from retrieved entries."""
 
+from __future__ import annotations
+
 from typing import Iterable
 
 from core.memory_entry import MemoryEntry
@@ -7,8 +9,10 @@ from ms_utils import format_context
 
 
 class Reconstructor:
-    """Simple reconstructor that joins memory contents."""
+    """Combine memory fragments into a context string."""
 
     def build_context(self, memories: Iterable[MemoryEntry]) -> str:
-        lines = [m.content for m in memories]
+        # sort by timestamp so recent memories come last
+        ordered = sorted(memories, key=lambda m: m.timestamp)
+        lines = [m.content for m in ordered]
         return format_context(lines)

--- a/retrieval/cue_builder.py
+++ b/retrieval/cue_builder.py
@@ -1,1 +1,14 @@
-# Cue builder
+"""Construct retrieval cues from user text and agent state."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+
+def build_cue(text: str, *, tags: Iterable[str] | None = None, state: Dict[str, str] | None = None) -> str:
+    parts = [text]
+    if state:
+        parts.extend(f"{k}:{v}" for k, v in state.items())
+    if tags:
+        parts.extend(tags)
+    return " ".join(parts)

--- a/retrieval/retriever.py
+++ b/retrieval/retriever.py
@@ -1,25 +1,48 @@
-"""Simple memory retrieval using token overlap."""
+"""Memory retrieval using simple vector similarity."""
 
-from typing import Iterable, List, Set
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Iterable, List
 
 from core.memory_entry import MemoryEntry
 from encoding.encoder import encode_text
 
 
-def _jaccard(a: Set[str], b: Set[str]) -> float:
-    if not a or not b:
-        return 0.0
-    return len(a & b) / len(a | b)
-
-
 class Retriever:
-    """Naïve in-memory retriever using Jaccard similarity."""
+    """In-memory retriever using cosine similarity and recency bias."""
 
     def __init__(self, memories: Iterable[MemoryEntry]):
         self._memories = list(memories)
+        self._vocab: Dict[str, int] = {}
+        self._vectors: List[Dict[int, int]] = []
+        for m in self._memories:
+            vec = {}
+            for token in m.embedding:
+                idx = self._vocab.setdefault(token, len(self._vocab))
+                vec[idx] = vec.get(idx, 0) + 1
+            self._vectors.append(vec)
+
+    def _cosine(self, vec: Dict[int, int], other: Dict[int, int]) -> float:
+        dot = sum(vec.get(i, 0) * other.get(i, 0) for i in set(vec) | set(other))
+        norm_a = sum(v * v for v in vec.values()) ** 0.5
+        norm_b = sum(v * v for v in other.values()) ** 0.5
+        if norm_a and norm_b:
+            return dot / (norm_a * norm_b)
+        return 0.0
 
     def query(self, text: str, top_k: int = 5) -> List[MemoryEntry]:
-        query_tokens = set(encode_text(text))
-        scored = [(_jaccard(query_tokens, set(m.embedding)), m) for m in self._memories]
+        tokens = encode_text(text)
+        q_vec: Dict[int, int] = {}
+        for t in tokens:
+            idx = self._vocab.get(t)
+            if idx is not None:
+                q_vec[idx] = q_vec.get(idx, 0) + 1
+        scored = []
+        now = datetime.utcnow()
+        for memory, vec in zip(self._memories, self._vectors):
+            sim = self._cosine(q_vec, vec)
+            recency = 1 / ((now - memory.timestamp).total_seconds() + 1)
+            scored.append((sim + 0.1 * recency, memory))
         scored.sort(key=lambda item: item[0], reverse=True)
         return [m for _, m in scored[:top_k]]

--- a/storage/db_interface.py
+++ b/storage/db_interface.py
@@ -1,1 +1,45 @@
-# Storage backend
+"""SQLite-based persistence for memories."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, List
+
+from core.memory_entry import MemoryEntry
+
+
+class Database:
+    def __init__(self, path: str | Path = "memory.db") -> None:
+        self.path = Path(path)
+        self.conn = sqlite3.connect(self.path)
+        self._setup()
+
+    def _setup(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS memories (content TEXT, timestamp REAL, emotions TEXT)"
+        )
+        self.conn.commit()
+
+    def save(self, entry: MemoryEntry) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO memories VALUES (?, ?, ?)",
+            (
+                entry.content,
+                entry.timestamp.timestamp(),
+                ",".join(entry.emotions),
+            ),
+        )
+        self.conn.commit()
+
+    def load_all(self) -> List[MemoryEntry]:
+        cur = self.conn.cursor()
+        rows = cur.execute("SELECT content, timestamp, emotions FROM memories").fetchall()
+        entries: List[MemoryEntry] = []
+        for content, ts, emotions in rows:
+            entries.append(
+                MemoryEntry(content=content, embedding=[], emotions=emotions.split(","))
+            )
+        return entries

--- a/storage/indexer.py
+++ b/storage/indexer.py
@@ -1,1 +1,16 @@
-# Vector index manager
+"""In-memory vector index built on top of Retriever."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from core.memory_entry import MemoryEntry
+from retrieval.retriever import Retriever
+
+
+class VectorIndexer:
+    def __init__(self, memories: Iterable[MemoryEntry]):
+        self._retriever = Retriever(memories)
+
+    def query(self, text: str, top_k: int = 5):
+        return self._retriever.query(text, top_k=top_k)

--- a/tests/test_emotions_and_dreaming.py
+++ b/tests/test_emotions_and_dreaming.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.emotion_model import analyze_emotions
+from dreaming.dream_engine import DreamEngine
+from core.memory_entry import MemoryEntry
+from datetime import datetime
+
+
+def test_analyze_emotions_positive():
+    assert "positive" in analyze_emotions("I am happy today")
+
+
+def test_dream_engine_summarize():
+    engine = DreamEngine()
+    mems = [MemoryEntry(content="a cat", embedding=[], timestamp=datetime.utcnow())]
+    summary = engine.summarize(mems)
+    assert "Dream:" in summary


### PR DESCRIPTION
## Summary
- add memory type classes and working memory manager
- expand `MemoryManager` to coordinate memory systems
- implement emotion model, cue builder, dream engine
- upgrade retrieval with cosine similarity
- provide simple LLM router and local stub
- persist memories via SQLite and vector index wrapper
- add tests for emotion and dreaming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcab43a408322af973c2b12248f63