### PR TITLE
Add minimal LLM API wrappers

### DIFF
--- a/llm/base_interface.py
+++ b/llm/base_interface.py
@@ -1,1 +1,17 @@
-# Abstract LLM interface
+"""Abstract base interface for LLM backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseLLM(ABC):
+    """Base class that all model wrappers must implement."""
+
+    @abstractmethod
+    def generate(self, prompt: str) -> str:
+        """Generate a completion for the given prompt."""
+        raise NotImplementedError
+
+
+__all__ = ["BaseLLM"]

--- a/llm/claude_api.py
+++ b/llm/claude_api.py
@@ -1,1 +1,42 @@
-# Claude model wrapper
+"""Minimal Anthropic Claude API wrapper."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from llm.base_interface import BaseLLM
+
+try:  # pragma: no cover - optional dependency
+    import anthropic
+except Exception:  # pragma: no cover - fallback when package missing
+    anthropic = None
+
+
+class ClaudeBackend(BaseLLM):
+    """Wrapper around the ``anthropic`` package."""
+
+    def __init__(self, model: str = "claude-3-opus-20240229", api_key: str | None = None) -> None:
+        self.model = model
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        if anthropic is not None and self.api_key:
+            self.client = anthropic.Anthropic(api_key=self.api_key)
+        else:  # pragma: no cover - degrade gracefully
+            self.client = None
+
+    def generate(self, prompt: str) -> str:
+        if self.client is None:
+            return f"Claude unavailable: {prompt}"
+        resp: Any = self.client.messages.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=512,
+        )
+        # anthropic 0.24 returns resp.content[0].text
+        content = getattr(resp, "content", None)
+        if isinstance(content, list) and content:
+            return getattr(content[0], "text", "").strip()
+        return getattr(resp, "completion", "").strip()
+
+
+__all__ = ["ClaudeBackend"]

--- a/llm/gemini_api.py
+++ b/llm/gemini_api.py
@@ -1,1 +1,35 @@
-# Gemini model wrapper
+"""Minimal Google Gemini API wrapper."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from llm.base_interface import BaseLLM
+
+try:  # pragma: no cover - optional dependency
+    import google.generativeai as genai
+except Exception:  # pragma: no cover - fallback when package missing
+    genai = None
+
+
+class GeminiBackend(BaseLLM):
+    """Wrapper around ``google.generativeai`` package."""
+
+    def __init__(self, model: str = "gemini-pro", api_key: str | None = None) -> None:
+        self.model_name = model
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY")
+        if genai is not None and self.api_key:
+            genai.configure(api_key=self.api_key)
+            self.model = genai.GenerativeModel(model)
+        else:  # pragma: no cover - degrade gracefully
+            self.model = None
+
+    def generate(self, prompt: str) -> str:
+        if self.model is None:
+            return f"Gemini unavailable: {prompt}"
+        resp: Any = self.model.generate_content(prompt)
+        return getattr(resp, "text", str(resp)).strip()
+
+
+__all__ = ["GeminiBackend"]

--- a/llm/llm_router.py
+++ b/llm/llm_router.py
@@ -4,10 +4,20 @@ from __future__ import annotations
 
 from typing import Literal
 
+from llm.base_interface import BaseLLM
 from llm.local_llm import LocalLLM
+from llm.openai_api import OpenAIBackend
+from llm.claude_api import ClaudeBackend
+from llm.gemini_api import GeminiBackend
 
 
-def get_llm(name: Literal["local"] = "local") -> LocalLLM:
+def get_llm(name: Literal["local", "openai", "claude", "gemini"] = "local") -> BaseLLM:
     if name == "local":
         return LocalLLM()
+    if name == "openai":
+        return OpenAIBackend()
+    if name == "claude":
+        return ClaudeBackend()
+    if name == "gemini":
+        return GeminiBackend()
     raise ValueError(f"Unknown LLM: {name}")

--- a/llm/local_llm.py
+++ b/llm/local_llm.py
@@ -1,5 +1,10 @@
 """Extremely small local LLM stub."""
 
-class LocalLLM:
+from __future__ import annotations
+
+from llm.base_interface import BaseLLM
+
+
+class LocalLLM(BaseLLM):
     def generate(self, prompt: str) -> str:
         return f"Echo: {prompt}"

--- a/llm/openai_api.py
+++ b/llm/openai_api.py
@@ -1,1 +1,35 @@
-# OpenAI model wrapper
+"""Minimal OpenAI API wrapper."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from llm.base_interface import BaseLLM
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover - fallback when package missing
+    openai = None
+
+
+class OpenAIBackend(BaseLLM):
+    """Wrapper around ``openai`` package."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None) -> None:
+        self.model = model
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if openai is not None and self.api_key:
+            openai.api_key = self.api_key
+
+    def generate(self, prompt: str) -> str:
+        if openai is None:
+            return f"OpenAI unavailable: {prompt}"
+        resp: Any = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+
+
+__all__ = ["OpenAIBackend"]


### PR DESCRIPTION
## Summary
- define `BaseLLM` abstract class with `generate` method
- implement simple wrappers for OpenAI, Claude and Gemini APIs
- make `LocalLLM` subclass `BaseLLM`
- expand router to select any backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd2f6120c83229e04d2d24dc408ae