### PR TITLE
Add tagging, logger, and scheduler utilities

### DIFF
--- a/encoding/tagging.py
+++ b/encoding/tagging.py
@@ -1,1 +1,23 @@
-# Tagging pipeline
+"""Keyword-based tagging pipeline."""
+
+from __future__ import annotations
+
+from typing import List
+
+from encoding.encoder import encode_text
+
+# Simple mapping of categories to keyword sets
+_TAG_VOCAB = {
+    "animal": {"cat", "dog", "bird", "fish"},
+    "greeting": {"hello", "hi", "hey"},
+    "food": {"pizza", "apple", "bread", "cake"},
+}
+
+
+def tag_text(text: str) -> List[str]:
+    """Return list of tags detected in text based on keyword matches."""
+    tokens = set(encode_text(text))
+    tags = [name for name, words in _TAG_VOCAB.items() if tokens & words]
+    if not tags:
+        tags.append("misc")
+    return tags

--- a/ms_utils/__init__.py
+++ b/ms_utils/__init__.py
@@ -1,5 +1,7 @@
 """Utilities package."""
 
 from .helpers import format_context
+from .logger import Logger
+from .scheduler import Scheduler
 
-__all__ = ["format_context"]
+__all__ = ["format_context", "Logger", "Scheduler"]

--- a/ms_utils/logger.py
+++ b/ms_utils/logger.py
@@ -1,1 +1,28 @@
-# Logger utility
+"""Minimal logger used across the project."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+class Logger:
+    """Very small logger printing timestamped messages."""
+
+    def __init__(self, name: str = "LLM") -> None:
+        self.name = name
+
+    def _log(self, level: str, message: str) -> None:
+        ts = datetime.utcnow().isoformat()
+        print(f"[{ts}] {self.name} {level}: {message}")
+
+    def info(self, message: str) -> None:
+        self._log("INFO", message)
+
+    def warning(self, message: str) -> None:
+        self._log("WARN", message)
+
+    def error(self, message: str) -> None:
+        self._log("ERROR", message)
+
+
+__all__ = ["Logger"]

--- a/ms_utils/scheduler.py
+++ b/ms_utils/scheduler.py
@@ -1,1 +1,36 @@
-# Background task scheduler
+"""Simple background scheduler for periodic tasks."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, List
+
+
+class Scheduler:
+    """Run functions at a fixed interval in background threads."""
+
+    def __init__(self) -> None:
+        self._threads: List[threading.Thread] = []
+        self._stop = threading.Event()
+
+    def schedule(self, interval: float, func: Callable, *args, **kwargs) -> None:
+        """Start executing ``func`` every ``interval`` seconds."""
+
+        def loop() -> None:
+            while not self._stop.is_set():
+                time.sleep(interval)
+                func(*args, **kwargs)
+
+        t = threading.Thread(target=loop, daemon=True)
+        t.start()
+        self._threads.append(t)
+
+    def stop(self) -> None:
+        """Stop all scheduled tasks."""
+        self._stop.set()
+        for t in list(self._threads):
+            t.join(timeout=0)
+
+
+__all__ = ["Scheduler"]


### PR DESCRIPTION
## Summary
- implement simple keyword based tagging
- add basic timestamped logger
- create simple background task scheduler
- expose utilities via `ms_utils.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd3a4ef9c832288f1dacd3c5e2f0c