### PR TITLE
Support embeddings and metadata in DB

### DIFF
--- a/cli/memory_cli.py
+++ b/cli/memory_cli.py
@@ -6,6 +6,7 @@ import argparse
 
 from core.emotion_model import analyze_emotions
 from core.memory_entry import MemoryEntry
+from encoding.encoder import encode_text
 from dreaming.dream_engine import DreamEngine
 from retrieval.retriever import Retriever
 from storage.db_interface import Database
@@ -22,7 +23,12 @@ def list_memories(db: Database) -> None:
 def add_memory(db: Database, text: str) -> None:
     """Add a new memory entry to the database."""
     emotions = analyze_emotions(text)
-    entry = MemoryEntry(content=text, embedding=[], emotions=emotions)
+    entry = MemoryEntry(
+        content=text,
+        embedding=encode_text(text),
+        emotions=emotions,
+        metadata={},
+    )
     db.save(entry)
     print("Memory added.")
 

--- a/storage/db_interface.py
+++ b/storage/db_interface.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
+import json
+from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List
 
@@ -18,28 +20,38 @@ class Database:
     def _setup(self) -> None:
         cur = self.conn.cursor()
         cur.execute(
-            "CREATE TABLE IF NOT EXISTS memories (content TEXT, timestamp REAL, emotions TEXT)"
+            "CREATE TABLE IF NOT EXISTS memories (content TEXT, timestamp REAL, embedding TEXT, emotions TEXT, metadata TEXT)"
         )
         self.conn.commit()
 
     def save(self, entry: MemoryEntry) -> None:
         cur = self.conn.cursor()
         cur.execute(
-            "INSERT INTO memories VALUES (?, ?, ?)",
+            "INSERT INTO memories VALUES (?, ?, ?, ?, ?)",
             (
                 entry.content,
                 entry.timestamp.timestamp(),
+                json.dumps(entry.embedding),
                 ",".join(entry.emotions),
+                json.dumps(entry.metadata),
             ),
         )
         self.conn.commit()
 
     def load_all(self) -> List[MemoryEntry]:
         cur = self.conn.cursor()
-        rows = cur.execute("SELECT content, timestamp, emotions FROM memories").fetchall()
+        rows = cur.execute(
+            "SELECT content, timestamp, embedding, emotions, metadata FROM memories"
+        ).fetchall()
         entries: List[MemoryEntry] = []
-        for content, ts, emotions in rows:
+        for content, ts, emb, emotions, metadata in rows:
             entries.append(
-                MemoryEntry(content=content, embedding=[], emotions=emotions.split(","))
+                MemoryEntry(
+                    content=content,
+                    embedding=json.loads(emb) if emb else [],
+                    timestamp=datetime.utcfromtimestamp(ts),
+                    emotions=emotions.split(",") if emotions else [],
+                    metadata=json.loads(metadata) if metadata else {},
+                )
             )
         return entries

--- a/tests/test_db_persistence.py
+++ b/tests/test_db_persistence.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from storage.db_interface import Database
+from core.memory_entry import MemoryEntry
+
+
+def test_round_trip_embedding_and_metadata(tmp_path):
+    db = Database(tmp_path / "mem.db")
+    entry = MemoryEntry(
+        content="hello world",
+        embedding=["hello", "world"],
+        emotions=["neutral"],
+        metadata={"role": "test"},
+    )
+    db.save(entry)
+    loaded = db.load_all()
+    assert loaded
+    loaded_entry = loaded[0]
+    assert loaded_entry.embedding == entry.embedding
+    assert loaded_entry.metadata == entry.metadata


### PR DESCRIPTION
## Summary
- extend database schema to store embeddings and metadata
- serialize/deserialize those fields when saving or loading
- enhance CLI memory addition to include embeddings
- add regression test for round-trip persistence of embedding and metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bf9b784483228c2231093d5c8795