### PR TITLE
Add optional transformer embeddings

### DIFF
--- a/core/memory_entry.py
+++ b/core/memory_entry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Dict
+from typing import List, Dict, Sequence
 
 
 @dataclass
@@ -10,7 +10,7 @@ class MemoryEntry:
     """Single piece of stored memory."""
 
     content: str
-    embedding: List[str]
+    embedding: List[str] | Sequence[float]
     timestamp: datetime = field(default_factory=datetime.utcnow)
     emotions: List[str] = field(default_factory=list)
     metadata: Dict[str, str] = field(default_factory=dict)

--- a/docs/summary_report.md
+++ b/docs/summary_report.md
@@ -6,6 +6,13 @@ The **LLMemory system** is a local-first, reconstructive memory architecture for
 
 ---
 
+## Dependencies
+
+- Python 3.10+
+- [sentence-transformers](https://www.sbert.net/) *(optional)* — used by `encoding/encoder.py` for generating real embeddings when installed.
+
+---
+
 ## 📁 Project Directory Structure
 
 ```

--- a/encoding/encoder.py
+++ b/encoding/encoder.py
@@ -1,11 +1,40 @@
-"""Simple token encoder for tests."""
+"""Simple text encoder used across the project."""
+
+from __future__ import annotations
 
 import re
-from typing import List
+from typing import List, Sequence
 
 _TOKEN_RE = re.compile(r"\w+")
 
+_model = None
+_model_failed = False
 
-def encode_text(text: str) -> List[str]:
-    """Tokenize text into lowercase word tokens."""
+
+def _load_model():
+    """Lazily load a sentence-transformers model if available."""
+    global _model, _model_failed
+    if _model is not None or _model_failed:
+        return _model
+    try:
+        from sentence_transformers import SentenceTransformer
+    except Exception:  # pragma: no cover - optional dependency may not exist
+        _model_failed = True
+        return None
+    _model = SentenceTransformer("all-MiniLM-L6-v2")
+    return _model
+
+
+def encode_text(text: str) -> List[str] | List[float]:
+    """Return an embedding for text.
+
+    If ``sentence_transformers`` is installed, this returns a vector from a
+    small pretrained model. Otherwise a simple token list is returned for use
+    in tests.
+    """
+
+    model = _load_model()
+    if model is not None:
+        vec: Sequence[float] = model.encode(text)
+        return list(vec)
     return _TOKEN_RE.findall(text.lower())

--- a/tests/test_encoder_transformer.py
+++ b/tests/test_encoder_transformer.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from encoding import encoder
+
+
+def test_encode_text_with_transformer():
+    fake_model = MagicMock()
+    fake_model.encode.return_value = [0.1, 0.2, 0.3]
+    with patch.object(encoder, "_load_model", return_value=fake_model):
+        result = encoder.encode_text("hello world")
+        assert result == [0.1, 0.2, 0.3]
+        fake_model.encode.assert_called_once_with("hello world")


### PR DESCRIPTION
## Summary
- support optional sentence_transformers embeddings with lazy load
- let `MemoryEntry` hold real embedding vectors
- document the optional dependency
- test encoder with mocked transformer model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c07046a4832293d5e275f4f5f6d5