### PR TITLE
Add optional FAISS index and tests

### DIFF
--- a/retrieval/retriever.py
+++ b/retrieval/retriever.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Sequence
 
 from core.memory_entry import MemoryEntry
 from encoding.encoder import encode_text
+
+try:  # pragma: no cover - optional dependency
+    from storage.faiss_index import FaissIndex
+except Exception:  # pragma: no cover - faiss may not be available
+    FaissIndex = None
 
 
 class Retriever:
@@ -14,14 +19,28 @@ class Retriever:
 
     def __init__(self, memories: Iterable[MemoryEntry]):
         self._memories = list(memories)
+        self._index = None
+        self._dense_vectors: List[List[float]] = []
         self._vocab: Dict[str, int] = {}
         self._vectors: List[Dict[int, int]] = []
-        for m in self._memories:
-            vec = {}
-            for token in m.embedding:
-                idx = self._vocab.setdefault(token, len(self._vocab))
-                vec[idx] = vec.get(idx, 0) + 1
-            self._vectors.append(vec)
+
+        if self._memories and self._memories[0].embedding and isinstance(
+            self._memories[0].embedding[0], (float, int)
+        ):
+            # numeric embeddings
+            self._dense_vectors = [list(map(float, m.embedding)) for m in self._memories]
+            if FaissIndex is not None:
+                idx = FaissIndex(self._memories)
+                if idx.available:
+                    self._index = idx
+        else:
+            # token-based embeddings
+            for m in self._memories:
+                vec = {}
+                for token in m.embedding:
+                    idx = self._vocab.setdefault(token, len(self._vocab))
+                    vec[idx] = vec.get(idx, 0) + 1
+                self._vectors.append(vec)
 
     def _cosine(self, vec: Dict[int, int], other: Dict[int, int]) -> float:
         dot = sum(vec.get(i, 0) * other.get(i, 0) for i in set(vec) | set(other))
@@ -31,15 +50,42 @@ class Retriever:
             return dot / (norm_a * norm_b)
         return 0.0
 
+    def _cosine_dense(self, a: Sequence[float], b: Sequence[float]) -> float:
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = sum(x * x for x in a) ** 0.5
+        norm_b = sum(x * x for x in b) ** 0.5
+        if norm_a and norm_b:
+            return dot / (norm_a * norm_b)
+        return 0.0
+
     def query(self, text: str, top_k: int = 5) -> List[MemoryEntry]:
-        tokens = encode_text(text)
+        embedding = encode_text(text)
+        now = datetime.utcnow()
+
+        if (
+            self._index is not None
+            and embedding
+            and isinstance(embedding[0], (float, int))
+        ):
+            idxs = self._index.query(embedding, top_k)
+            return [self._memories[i] for i in idxs]
+
+        if self._dense_vectors and embedding and isinstance(embedding[0], (float, int)):
+            scored = []
+            for memory, vec in zip(self._memories, self._dense_vectors):
+                sim = self._cosine_dense(embedding, vec)
+                recency = 1 / ((now - memory.timestamp).total_seconds() + 1)
+                scored.append((sim + 0.1 * recency, memory))
+            scored.sort(key=lambda item: item[0], reverse=True)
+            return [m for _, m in scored[:top_k]]
+
+        tokens = embedding  # type: ignore[assignment]
         q_vec: Dict[int, int] = {}
         for t in tokens:
             idx = self._vocab.get(t)
             if idx is not None:
                 q_vec[idx] = q_vec.get(idx, 0) + 1
         scored = []
-        now = datetime.utcnow()
         for memory, vec in zip(self._memories, self._vectors):
             sim = self._cosine(q_vec, vec)
             recency = 1 / ((now - memory.timestamp).total_seconds() + 1)

--- a/storage/faiss_index.py
+++ b/storage/faiss_index.py
@@ -1,0 +1,45 @@
+"""Optional vector index using FAISS if available."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - numpy may not be installed
+    np = None
+
+from core.memory_entry import MemoryEntry
+
+try:  # pragma: no cover - optional dependency
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - faiss may not be installed
+    faiss = None
+
+
+class FaissIndex:
+    """Wrapper around a FAISS index for memory retrieval."""
+
+    def __init__(self, memories: Iterable[MemoryEntry]):
+        self._memories = list(memories)
+        self._index = None
+        if faiss is None or np is None or not self._memories:
+            return
+        first = self._memories[0].embedding
+        if not first or not isinstance(first[0], (float, int)):
+            return
+        dim = len(first)
+        vectors = np.array([m.embedding for m in self._memories], dtype="float32")
+        self._index = faiss.IndexFlatL2(dim)
+        self._index.add(vectors)
+
+    @property
+    def available(self) -> bool:
+        return self._index is not None
+
+    def query(self, vector: Sequence[float], top_k: int = 5) -> List[int]:
+        if self._index is None or np is None:
+            return []
+        vec = np.array([vector], dtype="float32")
+        _, indices = self._index.search(vec, top_k)
+        return [int(i) for i in indices[0]]

--- a/tests/test_faiss_index.py
+++ b/tests/test_faiss_index.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.memory_manager import MemoryManager
+from retrieval.retriever import Retriever
+import storage.faiss_index as fi
+from encoding import encoder
+
+
+def test_retriever_with_faiss_index():
+    class FakeIndex:
+        def __init__(self, dim):
+            self.vectors = []
+
+        def add(self, arr):
+            for row in arr:
+                self.vectors.append(list(row))
+
+        def search(self, arr, k):
+            q = arr[0]
+            dists = [sum((v_i - q_i) ** 2 for v_i, q_i in zip(v, q)) for v in self.vectors]
+            idxs = sorted(range(len(dists)), key=dists.__getitem__)[:k]
+            return [[dists[i] for i in idxs]], [idxs]
+
+    fake_faiss = SimpleNamespace(IndexFlatL2=FakeIndex)
+
+    class FakeNP:
+        @staticmethod
+        def array(data, dtype=None):
+            return [list(row) for row in data]
+
+    def fake_encode(text):
+        mapping = {
+            "the cat sat on the mat": [1.0, 0.0],
+            "dogs are wonderful companions": [0.0, 1.0],
+            "cat": [1.0, 0.0],
+        }
+        return mapping[text]
+
+    with patch.object(fi, "faiss", fake_faiss):
+        with patch.object(fi, "np", FakeNP):
+            with patch.object(encoder, "encode_text", side_effect=fake_encode):
+                with patch("core.memory_types.episodic.encode_text", side_effect=fake_encode):
+                    with patch("retrieval.retriever.encode_text", side_effect=fake_encode):
+                        manager = MemoryManager()
+                        manager.add("the cat sat on the mat")
+                        manager.add("dogs are wonderful companions")
+
+                        retriever = Retriever(manager.all())
+                        results = retriever.query("cat", top_k=1)
+                        assert results
+                        assert results[0].content == "the cat sat on the mat"


### PR DESCRIPTION
## Summary
- implement `FaissIndex` using FAISS if available
- integrate retriever with FAISS-based search and dense fallback
- add unit test exercising the FAISS path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c65a27bc8322b9ed0ae2a74744a5