### PR TITLE
Add sentiment-based emotion model and mood-aware retrieval

### DIFF
--- a/core/emotion_model.py
+++ b/core/emotion_model.py
@@ -1,21 +1,42 @@
-"""Very small rule-based emotion analyzer."""
+"""Minimal sentiment based emotion analyzer."""
 
 from __future__ import annotations
 
 from typing import List
 
-POSITIVE = {"happy", "joy", "love", "great", "awesome", "good"}
-NEGATIVE = {"sad", "angry", "bad", "terrible", "awful"}
+_classifier = None
+
+
+def _load_classifier():
+    """Load sentiment classifier lazily."""
+    global _classifier
+    if _classifier is None:  # pragma: no cover - heavy dependency may be missing
+        try:
+            from transformers import pipeline
+
+            _classifier = pipeline("sentiment-analysis")
+        except Exception:  # pragma: no cover - optional dependency
+            _classifier = None
+    return _classifier
 
 
 def analyze_emotions(text: str) -> List[str]:
-    """Return a list of detected emotion labels."""
-    words = set(text.lower().split())
-    emotions: List[str] = []
-    if words & POSITIVE:
-        emotions.append("positive")
-    if words & NEGATIVE:
-        emotions.append("negative")
-    if not emotions:
-        emotions.append("neutral")
-    return emotions
+    """Return a list of detected emotion labels using a classifier."""
+    clf = _load_classifier()
+    if clf is None:
+        return ["neutral"]
+
+    try:
+        result = clf(text)
+    except Exception:  # pragma: no cover - runtime issues
+        return ["neutral"]
+
+    if not result:
+        return ["neutral"]
+
+    label = str(result[0].get("label", "")).lower()
+    if "neg" in label:
+        return ["negative"]
+    if "pos" in label:
+        return ["positive"]
+    return ["neutral"]

--- a/tests/test_emotions_and_dreaming.py
+++ b/tests/test_emotions_and_dreaming.py
@@ -3,14 +3,20 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from core.emotion_model import analyze_emotions
+from unittest.mock import MagicMock, patch
+
+from core import emotion_model
 from dreaming.dream_engine import DreamEngine
 from core.memory_entry import MemoryEntry
 from datetime import datetime
 
 
 def test_analyze_emotions_positive():
-    assert "positive" in analyze_emotions("I am happy today")
+    fake_clf = MagicMock(return_value=[{"label": "POSITIVE"}])
+    with patch.object(emotion_model, "_load_classifier", return_value=fake_clf):
+        # reset cached classifier
+        emotion_model._classifier = None
+        assert "positive" in emotion_model.analyze_emotions("I am happy today")
 
 
 def test_dream_engine_summarize():

--- a/tests/test_mood_retrieval.py
+++ b/tests/test_mood_retrieval.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core import emotion_model
+from core.agent import Agent
+
+
+def test_agent_passes_mood_to_retriever():
+    fake_clf = MagicMock(return_value=[{"label": "POSITIVE"}])
+    with patch.object(emotion_model, "_load_classifier", return_value=fake_clf):
+        emotion_model._classifier = None
+        with patch("retrieval.retriever.Retriever.query", return_value=[]) as mock_q:
+            agent = Agent("local")
+            agent.receive("I am thrilled")
+            args, _ = mock_q.call_args
+            assert "mood:positive" in args[0]


### PR DESCRIPTION
## Summary
- switch to a transformers sentiment pipeline in `emotion_model`
- update `Agent.receive` to query memory with a mood cue
- test emotion classification via mocked classifier
- test that mood is included in retrieval queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c8a445648322828db6457e040303