### PR TITLE
Implement DreamEngine scheduler with pruning

### DIFF
--- a/core/memory_types/episodic.py
+++ b/core/memory_types/episodic.py
@@ -26,3 +26,8 @@ class EpisodicMemory:
 
     def all(self) -> List[MemoryEntry]:
         return list(self._entries)
+
+    def prune(self, max_entries: int) -> None:
+        """Drop oldest entries beyond ``max_entries``."""
+        if len(self._entries) > max_entries:
+            self._entries = self._entries[-max_entries:]

--- a/dreaming/dream_engine.py
+++ b/dreaming/dream_engine.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
+from ms_utils import format_context, Scheduler
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from core.memory_manager import MemoryManager
 from core.memory_entry import MemoryEntry
-from ms_utils import format_context
 
 
 class DreamEngine:
@@ -14,3 +17,36 @@ class DreamEngine:
     def summarize(self, memories: Iterable[MemoryEntry]) -> str:
         lines = [m.content for m in memories]
         return "Dream:" + " " + format_context(lines)
+
+    def run(
+        self,
+        manager: MemoryManager,
+        *,
+        interval: float = 60.0,
+        summary_size: int = 5,
+        max_entries: int = 100,
+    ) -> Scheduler:
+        """Periodically summarize recent memories and prune old ones.
+
+        Parameters
+        ----------
+        manager:
+            Memory manager providing episodic entries.
+        interval:
+            Seconds between summarization runs.
+        summary_size:
+            Number of most recent memories to summarize.
+        max_entries:
+            Maximum number of episodic memories to keep after pruning.
+        """
+
+        scheduler = Scheduler()
+
+        def _task() -> None:
+            recent = manager.all()[-summary_size:]
+            if recent:
+                manager.add(self.summarize(recent))
+            manager.prune(max_entries)
+
+        scheduler.schedule(interval, _task)
+        return scheduler

--- a/tests/test_dreaming_scheduler.py
+++ b/tests/test_dreaming_scheduler.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.memory_manager import MemoryManager
+from dreaming.dream_engine import DreamEngine
+
+
+def test_dream_run_summarizes_and_prunes():
+    manager = MemoryManager()
+    for i in range(7):
+        manager.add(f"event {i}")
+
+    def immediate(interval, func, *args, **kwargs):
+        func(*args, **kwargs)
+
+    with patch("ms_utils.scheduler.Scheduler.schedule", side_effect=immediate):
+        engine = DreamEngine()
+        engine.run(manager, interval=0.1, summary_size=2, max_entries=5)
+
+    mems = manager.all()
+    assert len(mems) == 5
+    assert any("Dream:" in m.content for m in mems)
+
+
+def test_manager_start_dreaming_uses_engine():
+    manager = MemoryManager()
+
+    with patch.object(DreamEngine, "run", return_value=None) as mock_run:
+        manager.start_dreaming(interval=1, summary_size=1, max_entries=10)
+        mock_run.assert_called_once()
+


### PR DESCRIPTION
## Summary
- schedule background dreaming of recent memories in `DreamEngine`
- enable pruning of episodic memories
- expose dreaming scheduler from `MemoryManager`
- add tests for scheduled summarization and pruning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c9aa4dc88322b187c9a5addbdbd2