### PR TITLE
Connect GUI to agent

### DIFF
--- a/docs/summary_report.md
+++ b/docs/summary_report.md
@@ -46,6 +46,18 @@ llmemory/
   - Dummy placeholders for memory, mood, and dreaming.
 - 📦 Downloadable project ZIP with code templates and GUI included.
 
+### 🚀 Launching the GUI
+
+Create an ``Agent`` instance and pass it to ``run_gui``:
+
+```python
+from core.agent import Agent
+from gui.qt_interface import run_gui
+
+agent = Agent("local")
+run_gui(agent)
+```
+
 ---
 
 ## 🔜 Next Steps

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from datetime import datetime
+import os
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+PyQt5 = pytest.importorskip("PyQt5")
+from PyQt5.QtWidgets import QApplication
+
+from gui.qt_interface import MemorySystemGUI
+from core.memory_entry import MemoryEntry
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def test_gui_handle_submit_updates_panels():
+    app = QApplication.instance() or QApplication([])
+
+    mock_agent = MagicMock()
+    mock_agent.receive.return_value = "reply"
+    mock_agent.working_memory.return_value = ["fact1", "fact2"]
+    mock_agent.mood = "happy"
+    mock_agent.memory.all.return_value = [
+        MemoryEntry(content="Dream: something", embedding=[], timestamp=datetime.utcnow())
+    ]
+
+    gui = MemorySystemGUI(mock_agent)
+    gui.input_box.setPlainText("hello")
+    gui.handle_submit()
+
+    assert mock_agent.receive.called
+    assert gui.response_list.item(0).text() == "reply"
+    assert "fact1" in gui.memory_box.toPlainText()
+    assert "happy" in gui.mood_box.toPlainText()
+    assert "Dream:" in gui.dream_box.toPlainText()
+
+    app.quit()


### PR DESCRIPTION
## Summary
- hook up `MemorySystemGUI` to real `Agent` logic
- show live working memory, mood and dream info
- document how to launch the GUI
- add integration test for GUI with a mocked agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ca72eae083228236d9deb8acb21a