### PR TITLE
Add reset CLI command and embedding options

### DIFF
--- a/cli/memory_cli.py
+++ b/cli/memory_cli.py
@@ -6,7 +6,7 @@ import argparse
 
 from core.emotion_model import analyze_emotions
 from core.memory_entry import MemoryEntry
-from encoding.encoder import encode_text
+from encoding.encoder import encode_text, set_model_name
 from dreaming.dream_engine import DreamEngine
 from retrieval.retriever import Retriever
 from storage.db_interface import Database
@@ -20,12 +20,12 @@ def list_memories(db: Database) -> None:
         print(f"{i}. {ts} - {mem.content}")
 
 
-def add_memory(db: Database, text: str) -> None:
+def add_memory(db: Database, text: str, model: str | None = None) -> None:
     """Add a new memory entry to the database."""
     emotions = analyze_emotions(text)
     entry = MemoryEntry(
         content=text,
-        embedding=encode_text(text),
+        embedding=encode_text(text, model_name=model),
         emotions=emotions,
         metadata={},
     )
@@ -33,9 +33,13 @@ def add_memory(db: Database, text: str) -> None:
     print("Memory added.")
 
 
-def query_memories(db: Database, text: str, top_k: int = 5) -> None:
+def query_memories(
+    db: Database, text: str, top_k: int = 5, model: str | None = None
+) -> None:
     """Query stored memories using vector similarity."""
     memories = db.load_all()
+    if model is not None:
+        set_model_name(model)
     retriever = Retriever(memories)
     results = retriever.query(text, top_k=top_k)
     for mem in results:
@@ -50,18 +54,48 @@ def dream_summary(db: Database) -> None:
     print(summary)
 
 
+def reset_database(db: Database, *, assume_yes: bool = False) -> None:
+    """Delete all memories after user confirmation."""
+    if not assume_yes:
+        ans = input("Delete all memories? [y/N] ").strip().lower()
+        if ans not in {"y", "yes"}:
+            print("Aborted.")
+            return
+    db.clear()
+    print("Database cleared.")
+
+
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Memory management CLI")
+    parser = argparse.ArgumentParser(
+        description="Memory management CLI for stored agent memories"
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("list", help="List stored memories")
 
     add_p = sub.add_parser("add", help="Add a new memory")
     add_p.add_argument("text", help="Memory text")
+    add_p.add_argument(
+        "--model",
+        default=None,
+        help="SentenceTransformer model for embedding",
+    )
 
     query_p = sub.add_parser("query", help="Query memories")
     query_p.add_argument("text", help="Query text")
-    query_p.add_argument("--top-k", type=int, default=5, help="Number of results")
+    query_p.add_argument(
+        "--top-k",
+        type=int,
+        default=5,
+        help="Number of results",
+    )
+    query_p.add_argument(
+        "--model",
+        default=None,
+        help="SentenceTransformer model for query",
+    )
+
+    sub.add_parser("reset", help="Delete all memories")
 
     sub.add_parser("dream", help="Generate dream summary")
 
@@ -72,11 +106,13 @@ def main(argv: list[str] | None = None) -> None:
     if args.cmd == "list":
         list_memories(db)
     elif args.cmd == "add":
-        add_memory(db, args.text)
+        add_memory(db, args.text, model=args.model)
     elif args.cmd == "query":
-        query_memories(db, args.text, top_k=args.top_k)
+        query_memories(db, args.text, top_k=args.top_k, model=args.model)
     elif args.cmd == "dream":
         dream_summary(db)
+    elif args.cmd == "reset":
+        reset_database(db)
 
 
 if __name__ == "__main__":

--- a/docs/summary_report.md
+++ b/docs/summary_report.md
@@ -89,3 +89,16 @@ run_gui(agent)
 ### 🧪 Testing & CLI
 - [ ] Build `test_memory_workflow.py` to simulate full memory loop.
 - [ ] Add CLI commands to query memory, trigger dreams, or reset state.
+
+### CLI Usage
+
+```
+python -m cli.memory_cli list
+python -m cli.memory_cli add "remember this" --model all-MiniLM-L6-v2
+python -m cli.memory_cli query "cats" --top-k 3 --model all-MiniLM-L6-v2
+python -m cli.memory_cli dream
+python -m cli.memory_cli reset
+```
+
+Use `--model` to select a sentence-transformers embedding model and `--top-k`
+to control query result count.

--- a/encoding/encoder.py
+++ b/encoding/encoder.py
@@ -9,6 +9,16 @@ _TOKEN_RE = re.compile(r"\w+")
 
 _model = None
 _model_failed = False
+_model_name = "all-MiniLM-L6-v2"
+
+
+def set_model_name(name: str) -> None:
+    """Specify which sentence-transformers model to use."""
+    global _model, _model_failed, _model_name
+    if name != _model_name:
+        _model_name = name
+        _model = None
+        _model_failed = False
 
 
 def _load_model():
@@ -21,17 +31,20 @@ def _load_model():
     except Exception:  # pragma: no cover - optional dependency may not exist
         _model_failed = True
         return None
-    _model = SentenceTransformer("all-MiniLM-L6-v2")
+    _model = SentenceTransformer(_model_name)
     return _model
 
 
-def encode_text(text: str) -> List[str] | List[float]:
+def encode_text(text: str, model_name: str | None = None) -> List[str] | List[float]:
     """Return an embedding for text.
 
     If ``sentence_transformers`` is installed, this returns a vector from a
     small pretrained model. Otherwise a simple token list is returned for use
     in tests.
     """
+
+    if model_name is not None:
+        set_model_name(model_name)
 
     model = _load_model()
     if model is not None:

--- a/storage/db_interface.py
+++ b/storage/db_interface.py
@@ -55,3 +55,9 @@ class Database:
                 )
             )
         return entries
+
+    def clear(self) -> None:
+        """Delete all stored memories."""
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM memories")
+        self.conn.commit()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli import memory_cli
+from storage.db_interface import Database
+
+
+def test_cli_flow(tmp_path, capsys, monkeypatch):
+    db = Database(tmp_path / "mem.db")
+
+    memory_cli.add_memory(db, "the cat sat", model=None)
+    memory_cli.list_memories(db)
+    out = capsys.readouterr().out
+    assert "cat" in out
+
+    memory_cli.query_memories(db, "cat", top_k=1, model=None)
+    out = capsys.readouterr().out
+    assert "cat" in out
+
+    memory_cli.dream_summary(db)
+    out = capsys.readouterr().out
+    assert "Dream:" in out
+
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: "y")
+    memory_cli.reset_database(db)
+    out = capsys.readouterr().out
+    assert "Database cleared." in out
+    memory_cli.list_memories(db)
+    out = capsys.readouterr().out
+    assert out.strip() == ""
+
+
+def test_model_argument_passed(tmp_path):
+    db = Database(tmp_path / "mem.db")
+    called = {}
+
+    def fake_encode(text, model_name=None):
+        called["text"] = text
+        called["model"] = model_name
+        return []
+
+    with patch("cli.memory_cli.encode_text", side_effect=fake_encode):
+        memory_cli.add_memory(db, "hello", model="test-model")
+
+    assert called["model"] == "test-model"


### PR DESCRIPTION
## Summary
- extend `Database` with a `clear()` method
- allow choosing embedding model in the encoder and CLI
- add `reset` subcommand to `memory_cli`
- document CLI usage
- test CLI subcommands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cf3e2be8832292b5c057074aa290