### PR TITLE
Persist memories with MemoryManager

### DIFF
--- a/tests/test_db_persistence.py
+++ b/tests/test_db_persistence.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from storage.db_interface import Database
 from core.memory_entry import MemoryEntry
+from core.memory_manager import MemoryManager
 
 
 def test_round_trip_embedding_and_metadata(tmp_path):
@@ -21,3 +22,13 @@ def test_round_trip_embedding_and_metadata(tmp_path):
     loaded_entry = loaded[0]
     assert loaded_entry.embedding == entry.embedding
     assert loaded_entry.metadata == entry.metadata
+
+
+def test_memory_manager_loads_existing_entries(tmp_path):
+    path = tmp_path / "mem.db"
+    mgr1 = MemoryManager(db_path=path)
+    mgr1.add("hello world")
+
+    mgr2 = MemoryManager(db_path=path)
+    all_entries = [m.content for m in mgr2.all()]
+    assert "hello world" in all_entries

--- a/tests/test_dreaming_scheduler.py
+++ b/tests/test_dreaming_scheduler.py
@@ -9,7 +9,7 @@ from dreaming.dream_engine import DreamEngine
 
 
 def test_dream_run_summarizes_and_prunes():
-    manager = MemoryManager()
+    manager = MemoryManager(db_path=":memory:")
     for i in range(7):
         manager.add(f"event {i}")
 
@@ -26,7 +26,7 @@ def test_dream_run_summarizes_and_prunes():
 
 
 def test_manager_start_dreaming_uses_engine():
-    manager = MemoryManager()
+    manager = MemoryManager(db_path=":memory:")
 
     with patch.object(DreamEngine, "run", return_value=None) as mock_run:
         manager.start_dreaming(interval=1, summary_size=1, max_entries=10)

--- a/tests/test_faiss_index.py
+++ b/tests/test_faiss_index.py
@@ -46,7 +46,7 @@ def test_retriever_with_faiss_index():
             with patch.object(encoder, "encode_text", side_effect=fake_encode):
                 with patch("core.memory_types.episodic.encode_text", side_effect=fake_encode):
                     with patch("retrieval.retriever.encode_text", side_effect=fake_encode):
-                        manager = MemoryManager()
+                        manager = MemoryManager(db_path=":memory:")
                         manager.add("the cat sat on the mat")
                         manager.add("dogs are wonderful companions")
 

--- a/tests/test_memory_workflow.py
+++ b/tests/test_memory_workflow.py
@@ -9,7 +9,7 @@ from reconstruction.reconstructor import Reconstructor
 
 
 def test_memory_add_and_retrieve():
-    manager = MemoryManager()
+    manager = MemoryManager(db_path=":memory:")
     manager.add("the cat sat on the mat")
     manager.add("dogs are wonderful companions")
 


### PR DESCRIPTION
## Summary
- hook MemoryManager to the SQLite database
- allow passing a db path to MemoryManager
- keep unit tests isolated with in-memory databases
- add a persistence test for MemoryManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d3d234188322805a7d8c346dde0e