### PR TITLE
Add tagging support for memory entries and retrieval cues

### DIFF
--- a/cli/memory_cli.py
+++ b/cli/memory_cli.py
@@ -7,6 +7,7 @@ import argparse
 from core.emotion_model import analyze_emotions
 from core.memory_entry import MemoryEntry
 from encoding.encoder import encode_text, set_model_name
+from encoding.tagging import tag_text
 from dreaming.dream_engine import DreamEngine
 from retrieval.retriever import Retriever
 from storage.db_interface import Database
@@ -23,11 +24,12 @@ def list_memories(db: Database) -> None:
 def add_memory(db: Database, text: str, model: str | None = None) -> None:
     """Add a new memory entry to the database."""
     emotions = analyze_emotions(text)
+    tags = tag_text(text)
     entry = MemoryEntry(
         content=text,
         embedding=encode_text(text, model_name=model),
         emotions=emotions,
-        metadata={},
+        metadata={"tags": tags},
     )
     db.save(entry)
     print("Memory added.")

--- a/core/agent.py
+++ b/core/agent.py
@@ -7,6 +7,7 @@ from typing import List
 from core.emotion_model import analyze_emotions
 from core.memory_manager import MemoryManager
 from retrieval.cue_builder import build_cue
+from encoding.tagging import tag_text
 from retrieval.retriever import Retriever
 from reconstruction.reconstructor import Reconstructor
 from llm import llm_router
@@ -32,7 +33,8 @@ class Agent:
 
         self.memory.add(text, emotions=emotions, metadata={"role": "user"})
 
-        cue = build_cue(text, state={"mood": self.mood})
+        tags = tag_text(text)
+        cue = build_cue(text, tags=tags, state={"mood": self.mood})
         retriever = Retriever(self.memory.all())
         retrieved = retriever.query(cue, top_k=5, mood=self.mood)
         reconstructor = Reconstructor()

--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -34,7 +34,13 @@ class MemoryManager:
 
     def add(self, content: str, *, emotions: Iterable[str] | None = None, metadata: dict | None = None) -> MemoryEntry:
         """Add content to episodic memory and update working memory."""
-        entry = self.episodic.add(content, emotions=emotions, metadata=metadata)
+        from encoding.tagging import tag_text
+
+        tags = tag_text(content)
+        meta = dict(metadata or {})
+        meta["tags"] = tags
+
+        entry = self.episodic.add(content, emotions=emotions, metadata=meta)
         self.db.save(entry)
         self.working.load(self.episodic.all())
         return entry

--- a/gui/qt_interface.py
+++ b/gui/qt_interface.py
@@ -7,6 +7,7 @@ from PyQt5.QtCore import Qt
 import sys
 
 from ms_utils import format_context
+from encoding.tagging import tag_text
 
 
 class MemoryBrowser(QDialog):
@@ -185,7 +186,8 @@ class MemorySystemGUI(QWidget):
             from retrieval.cue_builder import build_cue
             from retrieval.retriever import Retriever
 
-            cue = build_cue(user_input, state={"mood": self.agent.mood})
+            tags = tag_text(user_input)
+            cue = build_cue(user_input, tags=tags, state={"mood": self.agent.mood})
             retriever = Retriever(self.agent.memory.all())
             retrieved = retriever.query(cue, top_k=5, mood=self.agent.mood)
             context = [m.content for m in retrieved]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -12,6 +12,8 @@ def test_cli_flow(tmp_path, capsys, monkeypatch):
     db = Database(tmp_path / "mem.db")
 
     memory_cli.add_memory(db, "the cat sat", model=None)
+    stored = db.load_all()[0]
+    assert stored.metadata.get("tags") == ["animal"]
     memory_cli.list_memories(db)
     out = capsys.readouterr().out
     assert "cat" in out

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from datetime import datetime
 import os
 
@@ -30,7 +30,10 @@ def test_gui_handle_submit_updates_panels():
 
     gui = MemorySystemGUI(mock_agent)
     gui.input_box.setPlainText("hello")
-    gui.handle_submit()
+    with patch("retrieval.cue_builder.build_cue", return_value="cue") as mock_cue:
+        gui.handle_submit()
+        _, kwargs = mock_cue.call_args
+        assert kwargs.get("tags") == ["greeting"]
 
     assert mock_agent.receive.called
     assert gui.response_list.item(0).text() == "reply"

--- a/tests/test_memory_workflow.py
+++ b/tests/test_memory_workflow.py
@@ -10,7 +10,8 @@ from reconstruction.reconstructor import Reconstructor
 
 def test_memory_add_and_retrieve():
     manager = MemoryManager(db_path=":memory:")
-    manager.add("the cat sat on the mat")
+    entry = manager.add("the cat sat on the mat")
+    assert entry.metadata.get("tags") == ["animal"]
     manager.add("dogs are wonderful companions")
 
     retriever = Retriever(manager.all())

--- a/tests/test_tagged_retrieval.py
+++ b/tests/test_tagged_retrieval.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core import emotion_model
+from core.agent import Agent
+
+
+def test_agent_passes_tags_to_cue_builder():
+    fake_clf = MagicMock(return_value=[{"label": "POSITIVE"}])
+    with patch.object(emotion_model, "_load_classifier", return_value=fake_clf):
+        emotion_model._classifier = None
+        with patch("core.agent.build_cue", return_value="cue") as mock_cue:
+            with patch("retrieval.retriever.Retriever.query", return_value=[]):
+                agent = Agent("local")
+                agent.receive("hello cat")
+                _, kwargs = mock_cue.call_args
+                assert kwargs.get("tags") == ["animal", "greeting"]


### PR DESCRIPTION
## Summary
- tag new memories using `tag_text`
- include tags when building retrieval cues in the agent and GUI
- add CLI support for storing tags
- verify tags are persisted and used via new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840fea789488322aacda0981ca9e3fb