### PR TITLE
Persist semantic and procedural memories

### DIFF
--- a/storage/db_interface.py
+++ b/storage/db_interface.py
@@ -22,6 +22,12 @@ class Database:
         cur.execute(
             "CREATE TABLE IF NOT EXISTS memories (content TEXT, timestamp REAL, embedding TEXT, emotions TEXT, metadata TEXT)"
         )
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS semantic_memories (content TEXT, timestamp REAL, embedding TEXT, emotions TEXT, metadata TEXT)"
+        )
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS procedural_memories (content TEXT, timestamp REAL, embedding TEXT, emotions TEXT, metadata TEXT)"
+        )
         self.conn.commit()
 
     def save(self, entry: MemoryEntry) -> None:
@@ -73,6 +79,87 @@ class Database:
         cur = self.conn.cursor()
         cur.execute(
             "UPDATE memories SET content=?, embedding=?, emotions=?, metadata=? WHERE timestamp=?",
+            (
+                entry.content,
+                json.dumps(entry.embedding),
+                ",".join(entry.emotions),
+                json.dumps(entry.metadata),
+                timestamp.timestamp(),
+            ),
+        )
+        self.conn.commit()
+
+    # --- Semantic memory operations ---
+    def save_semantic(self, entry: MemoryEntry) -> None:
+        self._save_to_table("semantic_memories", entry)
+
+    def load_all_semantic(self) -> List[MemoryEntry]:
+        return self._load_from_table("semantic_memories")
+
+    def delete_semantic(self, timestamp: datetime) -> None:
+        self._delete_from_table("semantic_memories", timestamp)
+
+    def update_semantic(self, timestamp: datetime, entry: MemoryEntry) -> None:
+        self._update_table("semantic_memories", timestamp, entry)
+
+    # --- Procedural memory operations ---
+    def save_procedural(self, entry: MemoryEntry) -> None:
+        self._save_to_table("procedural_memories", entry)
+
+    def load_all_procedural(self) -> List[MemoryEntry]:
+        return self._load_from_table("procedural_memories")
+
+    def delete_procedural(self, timestamp: datetime) -> None:
+        self._delete_from_table("procedural_memories", timestamp)
+
+    def update_procedural(self, timestamp: datetime, entry: MemoryEntry) -> None:
+        self._update_table("procedural_memories", timestamp, entry)
+
+    # --- Internal helpers ---
+    def _save_to_table(self, table: str, entry: MemoryEntry) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?)",
+            (
+                entry.content,
+                entry.timestamp.timestamp(),
+                json.dumps(entry.embedding),
+                ",".join(entry.emotions),
+                json.dumps(entry.metadata),
+            ),
+        )
+        self.conn.commit()
+
+    def _load_from_table(self, table: str) -> List[MemoryEntry]:
+        cur = self.conn.cursor()
+        rows = cur.execute(
+            f"SELECT content, timestamp, embedding, emotions, metadata FROM {table}"
+        ).fetchall()
+        entries: List[MemoryEntry] = []
+        for content, ts, emb, emotions, metadata in rows:
+            entries.append(
+                MemoryEntry(
+                    content=content,
+                    embedding=json.loads(emb) if emb else [],
+                    timestamp=datetime.utcfromtimestamp(ts),
+                    emotions=emotions.split(",") if emotions else [],
+                    metadata=json.loads(metadata) if metadata else {},
+                )
+            )
+        return entries
+
+    def _delete_from_table(self, table: str, timestamp: datetime) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            f"DELETE FROM {table} WHERE timestamp=?",
+            (timestamp.timestamp(),),
+        )
+        self.conn.commit()
+
+    def _update_table(self, table: str, timestamp: datetime, entry: MemoryEntry) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            f"UPDATE {table} SET content=?, embedding=?, emotions=?, metadata=? WHERE timestamp=?",
             (
                 entry.content,
                 json.dumps(entry.embedding),

--- a/tests/test_db_persistence.py
+++ b/tests/test_db_persistence.py
@@ -24,6 +24,24 @@ def test_round_trip_embedding_and_metadata(tmp_path):
     assert loaded_entry.metadata == entry.metadata
 
 
+def test_semantic_and_procedural_round_trip(tmp_path):
+    db = Database(tmp_path / "mem.db")
+
+    sem = MemoryEntry(content="fact", embedding=["f"], emotions=[], metadata={"type": "sem"})
+    proc = MemoryEntry(content="skill", embedding=["p"], emotions=[], metadata={"type": "proc"})
+
+    db.save_semantic(sem)
+    db.save_procedural(proc)
+
+    loaded_sem = db.load_all_semantic()[0]
+    loaded_proc = db.load_all_procedural()[0]
+
+    assert loaded_sem.content == sem.content
+    assert loaded_sem.metadata == sem.metadata
+    assert loaded_proc.content == proc.content
+    assert loaded_proc.metadata == proc.metadata
+
+
 def test_memory_manager_loads_existing_entries(tmp_path):
     path = tmp_path / "mem.db"
     mgr1 = MemoryManager(db_path=path)
@@ -32,3 +50,17 @@ def test_memory_manager_loads_existing_entries(tmp_path):
     mgr2 = MemoryManager(db_path=path)
     all_entries = [m.content for m in mgr2.all()]
     assert "hello world" in all_entries
+
+
+def test_manager_loads_semantic_and_procedural(tmp_path):
+    path = tmp_path / "mem.db"
+    mgr1 = MemoryManager(db_path=path)
+    mgr1.add_semantic("sky is blue")
+    mgr1.add_procedural("breathing")
+
+    mgr2 = MemoryManager(db_path=path)
+    sem_contents = [m.content for m in mgr2.semantic.all()]
+    proc_contents = [m.content for m in mgr2.procedural.all()]
+
+    assert "sky is blue" in sem_contents
+    assert "breathing" in proc_contents


### PR DESCRIPTION
## Summary
- add semantic_memories and procedural_memories tables
- persist semantic & procedural entries via MemoryManager
- expose DB helpers for these tables
- tests for round‑tripping semantic/procedural entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ffab96dc8322a0166b92d1f57040