### PR TITLE
Use config for working memory size

### DIFF
--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -11,6 +11,7 @@ from core.memory_types.episodic import EpisodicMemory
 from core.memory_types.semantic import SemanticMemory
 from core.memory_types.procedural import ProceduralMemory
 from core.working_memory import WorkingMemory
+from reconstruction.reconstructor import _load_config
 from dreaming.dream_engine import DreamEngine
 from ms_utils.scheduler import Scheduler
 from storage.db_interface import Database
@@ -21,10 +22,12 @@ class MemoryManager:
 
     def __init__(self, db_path: str | Path = "memory.db") -> None:
         self.db = Database(db_path)
+        cfg = _load_config()
+        working_size = cfg.get("memory", {}).get("working_size", 10)
         self.episodic = EpisodicMemory()
         self.semantic = SemanticMemory()
         self.procedural = ProceduralMemory()
-        self.working = WorkingMemory()
+        self.working = WorkingMemory(working_size)
 
         # Load any existing memories from the database into memory stores
         episodic = self.db.load_all()

--- a/tests/test_config_working_memory.py
+++ b/tests/test_config_working_memory.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.memory_manager import MemoryManager
+
+
+def test_memory_manager_uses_config(monkeypatch):
+    monkeypatch.setattr(
+        "core.memory_manager._load_config",
+        lambda: {"memory": {"working_size": 3}},
+    )
+    manager = MemoryManager(db_path=":memory:")
+    assert manager.working.max_size == 3


### PR DESCRIPTION
## Summary
- load `memory.working_size` from YAML configuration using `_load_config`
- initialize `WorkingMemory` with configured size in `MemoryManager`
- add a unit test verifying configured working memory size is applied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841019056688322bfe9929293e6226b