### PR TITLE
Add custom LLM/db options

### DIFF
--- a/cli/memory_cli.py
+++ b/cli/memory_cli.py
@@ -119,6 +119,11 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description="Memory management CLI for stored agent memories"
     )
+    parser.add_argument(
+        "--db",
+        default="memory.db",
+        help="Path to SQLite database",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("list", help="List stored memories")
@@ -158,7 +163,7 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
-    db = Database()
+    db = Database(args.db)
 
     if args.cmd == "list":
         list_memories(db)

--- a/core/agent.py
+++ b/core/agent.py
@@ -16,8 +16,8 @@ from llm import llm_router
 class Agent:
     """Minimal conversational agent."""
 
-    def __init__(self, llm_name: str = "local") -> None:
-        self.memory = MemoryManager()
+    def __init__(self, llm_name: str = "local", db_path: str | None = None) -> None:
+        self.memory = MemoryManager(db_path=db_path or "memory.db")
         self.llm = llm_router.get_llm(llm_name)
         self.mood = "neutral"
 

--- a/docs/summary_report.md
+++ b/docs/summary_report.md
@@ -102,3 +102,13 @@ python -m cli.memory_cli reset
 
 Use `--model` to select a sentence-transformers embedding model and `--top-k`
 to control query result count.
+
+### Launching with custom backends
+
+You can run the main entry point with a specific LLM backend and database path:
+
+```
+python main.py repl --llm openai --db ./my.db
+python main.py gui --llm openai --db ./my.db
+python main.py cli --db ./my.db list
+```

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import argparse
 
 
-def run_repl():
+def run_repl(llm_name: str, db_path: str) -> None:
     """Run a simple interactive REPL using ``core.agent.Agent``."""
     from core.agent import Agent
 
-    agent = Agent("local")
+    agent = Agent(llm_name, db_path=db_path)
     try:
         while True:
             try:
@@ -32,21 +32,32 @@ def main(argv: list[str] | None = None) -> None:
         choices=["cli", "gui", "repl"],
         help="Operation mode: cli, gui or repl",
     )
+    parser.add_argument(
+        "--llm",
+        default="local",
+        help="LLM backend to use (e.g. local, openai)",
+    )
+    parser.add_argument(
+        "--db",
+        default="memory.db",
+        help="Path to SQLite database",
+    )
+
     args, remaining = parser.parse_known_args(argv)
 
     if args.mode == "cli":
         from cli.memory_cli import main as cli_main
 
-        cli_main(remaining)
+        cli_main(["--db", args.db, *remaining])
     elif args.mode == "gui":
         from gui.qt_interface import run_gui
 
         from core.agent import Agent
 
-        agent = Agent("local")
+        agent = Agent(args.llm, db_path=args.db)
         run_gui(agent)
     else:  # repl
-        run_repl()
+        run_repl(args.llm, args.db)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_options.py
+++ b/tests/test_main_options.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def test_main_cli_db_option(tmp_path):
+    db_path = tmp_path / "cli.db"
+    with patch("cli.memory_cli.Database") as MockDB, patch("cli.memory_cli.list_memories"):
+        MockDB.return_value = MagicMock(load_all=lambda: [])
+        main.main(["cli", "list", "--db", str(db_path)])
+        MockDB.assert_called_once_with(str(db_path))
+
+
+def test_main_calls_run_repl_with_options(tmp_path):
+    db_path = tmp_path / "mem.db"
+    with patch("main.run_repl") as mock_repl:
+        main.main(["repl", "--llm", "claude", "--db", str(db_path)])
+        mock_repl.assert_called_once_with("claude", str(db_path))
+
+
+def test_run_repl_creates_agent(tmp_path):
+    db_path = tmp_path / "mem.db"
+    with patch("core.agent.Agent") as MockAgent:
+        agent = MockAgent.return_value
+        agent.receive.side_effect = ["hi"]
+        with patch("builtins.input", side_effect=EOFError):
+            main.run_repl("openai", str(db_path))
+        MockAgent.assert_called_once_with("openai", db_path=str(db_path))
+


### PR DESCRIPTION
## Summary
- enable Agent to pick database path
- accept `--llm` and `--db` in main entry point
- pipe database path through `memory_cli`
- document starting the app with custom backends
- test propagation of new arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684102d5f6c8832297fa83d5fc77afa1