### PR TITLE
Refresh tags on edited memories

### DIFF
--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -72,8 +72,10 @@ class MemoryManager:
         if entry in self.episodic._entries:
             entry.content = new_content
             from encoding.encoder import encode_text
+            from encoding.tagging import tag_text
 
             entry.embedding = encode_text(new_content)
+            entry.metadata["tags"] = tag_text(new_content)
             self.db.update(entry.timestamp, entry)
             self.working.load(self.episodic.all())
 

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -11,8 +11,9 @@ import pytest
 PyQt5 = pytest.importorskip("PyQt5")
 from PyQt5.QtWidgets import QApplication
 
-from gui.qt_interface import MemorySystemGUI
+from gui.qt_interface import MemorySystemGUI, MemoryBrowser
 from core.memory_entry import MemoryEntry
+from core.memory_manager import MemoryManager
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -40,5 +41,24 @@ def test_gui_handle_submit_updates_panels():
     assert "fact1" in gui.memory_box.toPlainText()
     assert "happy" in gui.mood_box.toPlainText()
     assert "Dream:" in gui.dream_box.toPlainText()
+
+    app.quit()
+
+
+def test_memory_browser_edit_refreshes_tags(tmp_path):
+    app = QApplication.instance() or QApplication([])
+
+    manager = MemoryManager(db_path=tmp_path / "mem.db")
+    entry = manager.add("hello")
+
+    browser = MemoryBrowser(manager)
+    browser.display_memory(0)
+    browser.detail.setPlainText("the cat sat")
+    browser.save_current()
+
+    assert entry.metadata.get("tags") == ["animal"]
+    stored = manager.db.load_all()[0]
+    assert stored.metadata.get("tags") == ["animal"]
+    assert manager.working.contents()[0].metadata.get("tags") == ["animal"]
 
     app.quit()


### PR DESCRIPTION
## Summary
- ensure `MemoryManager.update` tags updated content
- test GUI memory editing refreshes tag info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684105f07d9083228d000cf9c81e78df