### PR TITLE
Improve tag-aware retrieval

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -36,7 +36,7 @@ class Agent:
         tags = tag_text(text)
         cue = build_cue(text, tags=tags, state={"mood": self.mood})
         retriever = Retriever(self.memory.all())
-        retrieved = retriever.query(cue, top_k=5, mood=self.mood)
+        retrieved = retriever.query(cue, top_k=5, mood=self.mood, tags=tags)
         reconstructor = Reconstructor()
         context = reconstructor.build_context(retrieved, mood=self.mood)
 

--- a/gui/qt_interface.py
+++ b/gui/qt_interface.py
@@ -189,7 +189,7 @@ class MemorySystemGUI(QWidget):
             tags = tag_text(user_input)
             cue = build_cue(user_input, tags=tags, state={"mood": self.agent.mood})
             retriever = Retriever(self.agent.memory.all())
-            retrieved = retriever.query(cue, top_k=5, mood=self.agent.mood)
+            retrieved = retriever.query(cue, top_k=5, mood=self.agent.mood, tags=tags)
             context = [m.content for m in retrieved]
             working = self.agent.working_memory()
             dream_entries = [

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -32,9 +32,12 @@ def test_gui_handle_submit_updates_panels():
     gui = MemorySystemGUI(mock_agent)
     gui.input_box.setPlainText("hello")
     with patch("retrieval.cue_builder.build_cue", return_value="cue") as mock_cue:
-        gui.handle_submit()
-        _, kwargs = mock_cue.call_args
-        assert kwargs.get("tags") == ["greeting"]
+        with patch("retrieval.retriever.Retriever.query", return_value=[] ) as mock_query:
+            gui.handle_submit()
+            _, kwargs = mock_cue.call_args
+            assert kwargs.get("tags") == ["greeting"]
+            _, q_kwargs = mock_query.call_args
+            assert q_kwargs.get("tags") == ["greeting"]
 
     assert mock_agent.receive.called
     assert gui.response_list.item(0).text() == "reply"

--- a/tests/test_tagged_retrieval.py
+++ b/tests/test_tagged_retrieval.py
@@ -13,8 +13,32 @@ def test_agent_passes_tags_to_cue_builder():
     with patch.object(emotion_model, "_load_classifier", return_value=fake_clf):
         emotion_model._classifier = None
         with patch("core.agent.build_cue", return_value="cue") as mock_cue:
-            with patch("retrieval.retriever.Retriever.query", return_value=[]):
+            with patch("retrieval.retriever.Retriever.query", return_value=[]) as mock_query:
                 agent = Agent("local")
                 agent.receive("hello cat")
                 _, kwargs = mock_cue.call_args
                 assert kwargs.get("tags") == ["animal", "greeting"]
+                _, q_kwargs = mock_query.call_args
+                assert q_kwargs.get("tags") == ["animal", "greeting"]
+
+from datetime import datetime
+from core.memory_entry import MemoryEntry
+from retrieval.retriever import Retriever
+
+
+def test_retriever_ranks_matching_tags_higher():
+    m1 = MemoryEntry(
+        content="cats are great",
+        embedding=["cats", "are", "great"],
+        timestamp=datetime(2020, 1, 1),
+        metadata={"tags": ["animal"]},
+    )
+    m2 = MemoryEntry(
+        content="hello there",
+        embedding=["hello", "there"],
+        timestamp=datetime(2020, 1, 1),
+        metadata={"tags": ["greeting"]},
+    )
+    retriever = Retriever([m1, m2])
+    results = retriever.query("unrelated", top_k=2, tags=["greeting"])
+    assert results[0] is m2


### PR DESCRIPTION
## Summary
- track memory tags in `Retriever`
- include tag overlap in similarity score
- pass tags from `Agent` and the GUI to `Retriever`
- test tag propagation and tag-based ranking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684106e154488322a141616c2f8b103f