### PR TITLE
Update metadata typing in MemoryEntry

### DIFF
--- a/core/memory_entry.py
+++ b/core/memory_entry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Dict, Sequence
+from typing import List, Dict, Sequence, Any
 
 
 @dataclass
@@ -13,4 +13,4 @@ class MemoryEntry:
     embedding: List[str] | Sequence[float]
     timestamp: datetime = field(default_factory=datetime.utcnow)
     emotions: List[str] = field(default_factory=list)
-    metadata: Dict[str, str] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- loosen typing for `MemoryEntry.metadata`
- import `Any` to support new type
- run existing test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410bced9b88322881c3cb2011d4507