### PR TITLE
Add dream control CLI commands

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -111,3 +111,11 @@ def test_semantic_and_procedural_cli(tmp_path, capsys, monkeypatch):
     out = capsys.readouterr().out
     assert "Procedural memory deleted." in out
     assert db.load_all_procedural() == []
+
+
+def test_start_and_stop_dreaming():
+    manager = MagicMock()
+    memory_cli.start_dream(manager, interval=5)
+    manager.start_dreaming.assert_called_once_with(interval=5)
+    memory_cli.stop_dream(manager)
+    manager.stop_dreaming.assert_called_once()


### PR DESCRIPTION
## Summary
- add MemoryManager imports and functions for start/stop dream in CLI
- expose `start-dream` and `stop-dream` subcommands with interval option
- handle the new commands in the CLI dispatch
- test CLI helpers for starting and stopping dreams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410c99f69c8322a724b141e827cd2f