### PR TITLE
Include semantic and procedural memory in retrieval

### DIFF
--- a/cli/memory_cli.py
+++ b/cli/memory_cli.py
@@ -46,9 +46,11 @@ def query_memories(
 ) -> None:
     """Query stored memories using vector similarity."""
     memories = db.load_all()
+    sem = db.load_all_semantic()
+    proc = db.load_all_procedural()
     if model is not None:
         set_model_name(model)
-    retriever = Retriever(memories)
+    retriever = Retriever(memories, semantic=sem, procedural=proc)
     results = retriever.query(text, top_k=top_k)
     for mem in results:
         logger.info(f"{mem.timestamp.isoformat()} - {mem.content}")

--- a/core/agent.py
+++ b/core/agent.py
@@ -35,7 +35,11 @@ class Agent:
 
         tags = tag_text(text)
         cue = build_cue(text, tags=tags, state={"mood": self.mood})
-        retriever = Retriever(self.memory.all())
+        retriever = Retriever(
+            self.memory.all(),
+            semantic=self.memory.semantic.all(),
+            procedural=self.memory.procedural.all(),
+        )
         retrieved = retriever.query(cue, top_k=5, mood=self.mood, tags=tags)
         reconstructor = Reconstructor()
         context = reconstructor.build_context(retrieved, mood=self.mood)

--- a/gui/qt_interface.py
+++ b/gui/qt_interface.py
@@ -188,7 +188,11 @@ class MemorySystemGUI(QWidget):
 
             tags = tag_text(user_input)
             cue = build_cue(user_input, tags=tags, state={"mood": self.agent.mood})
-            retriever = Retriever(self.agent.memory.all())
+            retriever = Retriever(
+                self.agent.memory.all(),
+                semantic=self.agent.memory.semantic.all(),
+                procedural=self.agent.memory.procedural.all(),
+            )
             retrieved = retriever.query(cue, top_k=5, mood=self.agent.mood, tags=tags)
             context = [m.content for m in retrieved]
             working = self.agent.working_memory()

--- a/tests/test_memory_workflow.py
+++ b/tests/test_memory_workflow.py
@@ -14,7 +14,11 @@ def test_memory_add_and_retrieve():
     assert entry.metadata.get("tags") == ["animal"]
     manager.add("dogs are wonderful companions")
 
-    retriever = Retriever(manager.all())
+    retriever = Retriever(
+        manager.all(),
+        semantic=manager.semantic.all(),
+        procedural=manager.procedural.all(),
+    )
     results = retriever.query("cat", top_k=1)
     assert results
     assert "cat" in results[0].content
@@ -22,3 +26,21 @@ def test_memory_add_and_retrieve():
     reconstructor = Reconstructor()
     context = reconstructor.build_context(results)
     assert "cat" in context
+
+
+def test_semantic_and_procedural_retrieval():
+    manager = MemoryManager(db_path=":memory:")
+    sem = manager.add_semantic("Paris is in France")
+    proc = manager.add_procedural("tie a knot by looping twice")
+
+    retriever = Retriever(
+        manager.all(),
+        semantic=manager.semantic.all(),
+        procedural=manager.procedural.all(),
+    )
+
+    res_sem = retriever.query("France", top_k=1)
+    assert res_sem and res_sem[0] is sem
+
+    res_proc = retriever.query("knot", top_k=1)
+    assert res_proc and res_proc[0] is proc


### PR DESCRIPTION
## Summary
- update Retriever to handle episodic, semantic and procedural memories with adjustable recency weights
- update Agent, CLI and GUI to pass all memory types to the Retriever
- add tests showing semantic/procedural retrieval works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410d554c58832283ab917def8dc091