### PR TITLE
Extend DB clear and test reset

### DIFF
--- a/storage/db_interface.py
+++ b/storage/db_interface.py
@@ -66,6 +66,8 @@ class Database:
         """Delete all stored memories."""
         cur = self.conn.cursor()
         cur.execute("DELETE FROM memories")
+        cur.execute("DELETE FROM semantic_memories")
+        cur.execute("DELETE FROM procedural_memories")
         self.conn.commit()
 
     def delete(self, timestamp: datetime) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -119,3 +119,17 @@ def test_start_and_stop_dreaming():
     manager.start_dreaming.assert_called_once_with(interval=5)
     memory_cli.stop_dream(manager)
     manager.stop_dreaming.assert_called_once()
+
+
+def test_reset_database_clears_all_categories(tmp_path):
+    db = Database(tmp_path / "mem.db")
+
+    memory_cli.add_memory(db, "a", model=None)
+    memory_cli.add_sem(db, "b")
+    memory_cli.add_proc(db, "c")
+
+    memory_cli.reset_database(db, assume_yes=True)
+
+    assert db.load_all() == []
+    assert db.load_all_semantic() == []
+    assert db.load_all_procedural() == []


### PR DESCRIPTION
## Summary
- clear semantic and procedural memories when clearing the database
- test that reset_database clears all categories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841101bbce48322ba595636f14db2f3