### PR TITLE
Fix OpenAI backend for new API

### DIFF
--- a/llm/openai_api.py
+++ b/llm/openai_api.py
@@ -25,6 +25,12 @@ class OpenAIBackend(BaseLLM):
     def generate(self, prompt: str) -> str:
         if openai is None:
             return f"OpenAI unavailable: {prompt}"
+        if hasattr(openai, "chat"):
+            resp: Any = openai.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return resp.choices[0].message.content.strip()
         resp: Any = openai.ChatCompletion.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],


### PR DESCRIPTION
## Summary
- support openai>=1.0 by checking for `openai.chat` endpoint
- keep fallback to old `ChatCompletion` for older packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d04723688322a94591b31a4863bc