### PR TITLE
Modernize chat GUI with countdown

### DIFF
--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -14,6 +14,7 @@ from core.working_memory import WorkingMemory
 from reconstruction.reconstructor import _load_config
 from dreaming.dream_engine import DreamEngine
 from ms_utils.scheduler import Scheduler
+import time
 from storage.db_interface import Database
 
 
@@ -137,6 +138,8 @@ class MemoryManager:
             summary_size=summary_size,
             max_entries=max_entries,
         )
+        self._dream_interval = interval
+        self._next_dream_time = time.monotonic() + interval
         return self._dream_scheduler
 
     def stop_dreaming(self) -> None:
@@ -144,3 +147,11 @@ class MemoryManager:
         sched = getattr(self, "_dream_scheduler", None)
         if isinstance(sched, Scheduler):
             sched.stop()
+        self._next_dream_time = None
+
+    def time_until_dream(self) -> float | None:
+        """Return seconds until the next scheduled dream or ``None``."""
+        next_time = getattr(self, "_next_dream_time", None)
+        if next_time is None:
+            return None
+        return max(0.0, next_time - time.monotonic())

--- a/dreaming/dream_engine.py
+++ b/dreaming/dream_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Iterable, TYPE_CHECKING
 
 from ms_utils import format_context, Scheduler
+import time
 from llm import llm_router
 from ms_utils.logger import Logger
 
@@ -76,6 +77,7 @@ class DreamEngine:
         """
 
         scheduler = Scheduler()
+        manager._next_dream_time = time.monotonic() + interval
 
         def _task() -> None:
             recent = manager.all()[-summary_size:]
@@ -87,6 +89,7 @@ class DreamEngine:
                 )
                 manager.add(summary)
             manager.prune(max_entries)
+            manager._next_dream_time = time.monotonic() + interval
 
         scheduler.schedule(interval, _task)
         return scheduler

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 
 PyQt5 = pytest.importorskip("PyQt5")
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QLabel
 
 from gui.qt_interface import MemorySystemGUI, MemoryBrowser
 from core.memory_entry import MemoryEntry
@@ -40,7 +40,8 @@ def test_gui_handle_submit_updates_panels():
             assert q_kwargs.get("tags") == ["greeting"]
 
     assert mock_agent.receive.called
-    assert gui.response_list.item(0).text() == "reply"
+    bubbles = gui.chat_widget.findChildren(QLabel)
+    assert bubbles[-1].text() == "reply"
     assert "fact1" in gui.memory_box.toPlainText()
     assert "happy" in gui.mood_box.toPlainText()
     assert "Dream:" in gui.dream_box.toPlainText()


### PR DESCRIPTION
## Summary
- refresh Qt interface with iPhone-like chat bubbles
- show countdown until the next dreaming cycle
- expose MemoryManager.time_until_dream and track next dream time
- adapt tests for new widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684123c358ec832295008bc25cdfcf28