### PR TITLE
Use emotion scores for retrieval weight

### DIFF
--- a/retrieval/retriever.py
+++ b/retrieval/retriever.py
@@ -107,7 +107,8 @@ class Retriever:
                     sim = self._cosine_dense(embedding, vec)
                     recency = 1 / ((now - memory.timestamp).total_seconds() + 1)
                     weight = self._recency_weights[self._types[i]]
-                    boost = 0.1 if mood in memory.emotions else 0.0
+                    score = memory.emotion_scores.get(mood, 0.0)
+                    boost = float(score)
                     tag_score = (
                         len(q_tags & self._tags[i]) / len(q_tags) if q_tags else 0.0
                     )
@@ -122,7 +123,8 @@ class Retriever:
                 sim = self._cosine_dense(embedding, vec)
                 recency = 1 / ((now - memory.timestamp).total_seconds() + 1)
                 weight = self._recency_weights[self._types[i]]
-                boost = 0.1 if mood and mood in memory.emotions else 0.0
+                score = memory.emotion_scores.get(mood, 0.0) if mood else 0.0
+                boost = float(score)
                 tag_score = (
                     len(q_tags & self._tags[i]) / len(q_tags) if q_tags else 0.0
                 )
@@ -141,7 +143,8 @@ class Retriever:
             sim = self._cosine(q_vec, vec)
             recency = 1 / ((now - memory.timestamp).total_seconds() + 1)
             weight = self._recency_weights[self._types[i]]
-            boost = 0.1 if mood and mood in memory.emotions else 0.0
+            score = memory.emotion_scores.get(mood, 0.0) if mood else 0.0
+            boost = float(score)
             tag_score = (
                 len(q_tags & self._tags[i]) / len(q_tags) if q_tags else 0.0
             )

--- a/tests/test_emotion_weighted_retrieval.py
+++ b/tests/test_emotion_weighted_retrieval.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from datetime import datetime
+from core.memory_entry import MemoryEntry
+from retrieval.retriever import Retriever
+
+
+def test_retriever_ranks_emotion_weighted_results():
+    m1 = MemoryEntry(
+        content="happy memory",
+        embedding=["a"],
+        timestamp=datetime(2020, 1, 1),
+        emotions=["happy"],
+        emotion_scores={"happy": 0.9},
+    )
+    m2 = MemoryEntry(
+        content="less happy memory",
+        embedding=["a"],
+        timestamp=datetime(2020, 1, 1),
+        emotions=["happy"],
+        emotion_scores={"happy": 0.1},
+    )
+    retriever = Retriever([m1, m2])
+    results = retriever.query("a", top_k=2, mood="happy")
+    assert results[0] is m1


### PR DESCRIPTION
## Summary
- boost retrieval ranking by each memory's emotion score rather than a constant
- test emotion weighted retrieval ranking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b7d9830483229dff3a5d54affaf8