### PR TITLE
Update emotion docs and mood example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,32 @@ Unit tests are located in the `tests/` directory and can be executed with:
 ```
 pytest
 ```
+
+## Emotions & Mood
+
+Memories record the emotion labels detected in the text along with an intensity score for each label. These labels are normalised to one of the following categories:
+
+- angry
+- disgust
+- embarrassed
+- fear
+- happy
+- love
+- neutral
+- pleasure
+- sad
+- surprise
+
+The intensity scores are stored in `MemoryEntry.emotion_scores` and used by the `Retriever`. When the agent's current `mood` matches a stored emotion, that memory receives a boost in ranking.
+
+Example:
+```python
+from core.memory_entry import MemoryEntry
+from retrieval.retriever import Retriever
+
+m1 = MemoryEntry(content="lost my toy", embedding=["a"], emotions=["sad"], emotion_scores={"sad": 0.9})
+m2 = MemoryEntry(content="found a toy", embedding=["a"], emotions=["happy"], emotion_scores={"happy": 0.8})
+retriever = Retriever([m1, m2])
+top = retriever.query("toy", mood="sad")[0]
+print(top.content)  # -> "lost my toy"
+```

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -36,9 +36,10 @@ response using a pluggable LLM backend. The main subsystems are shown below.
    - **procedural**: skills or instructions.
    The manager persists entries via ``Database`` and exposes helpers for
    adding, deleting and updating all types.
+   Each ``MemoryEntry`` stores detected emotion labels with an intensity score. Labels map to canonical categories: angry, disgust, embarrassed, fear, happy, love, neutral, pleasure, sad and surprise.
 3. **Retriever** – given a cue from ``cue_builder`` and optional mood or tags,
    ranks episodic, semantic and procedural memories using embeddings and
-   recency weighting.
+   recency weighting. Memories with high scores for the current mood are ranked higher.
 4. **Reconstructor** – merges retrieved memories into a context window for the
    next prompt.
 5. **DreamEngine** – background summarization. It periodically summarizes


### PR DESCRIPTION
## Summary
- document emotion intensity scoring and categories
- add example of mood weighted retrieval
- mention mood weighting in system architecture doc

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b9f85a4483229938b20a553b3eec