### PR TITLE
Refine fallback LLM messaging

### DIFF
--- a/llm/claude_api.py
+++ b/llm/claude_api.py
@@ -26,7 +26,7 @@ class ClaudeBackend(BaseLLM):
 
     def generate(self, prompt: str) -> str:
         if self.client is None:
-            return f"Claude unavailable: {prompt}"
+            return "Claude backend unavailable."
         resp: Any = self.client.messages.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],

--- a/llm/gemini_api.py
+++ b/llm/gemini_api.py
@@ -27,7 +27,7 @@ class GeminiBackend(BaseLLM):
 
     def generate(self, prompt: str) -> str:
         if self.model is None:
-            return f"Gemini unavailable: {prompt}"
+            return "Gemini backend unavailable."
         resp: Any = self.model.generate_content(prompt)
         return getattr(resp, "text", str(resp)).strip()
 

--- a/llm/local_llm.py
+++ b/llm/local_llm.py
@@ -7,4 +7,4 @@ from llm.base_interface import BaseLLM
 
 class LocalLLM(BaseLLM):
     def generate(self, prompt: str) -> str:
-        return f"Echo: {prompt}"
+        return "Local backend unavailable."

--- a/llm/openai_api.py
+++ b/llm/openai_api.py
@@ -24,7 +24,7 @@ class OpenAIBackend(BaseLLM):
 
     def generate(self, prompt: str) -> str:
         if openai is None:
-            return f"OpenAI unavailable: {prompt}"
+            return "OpenAI backend unavailable."
         if hasattr(openai, "chat"):
             resp: Any = openai.chat.completions.create(
                 model=self.model,

--- a/tests/test_llm_abstraction.py
+++ b/tests/test_llm_abstraction.py
@@ -47,7 +47,7 @@ def test_agent_and_cli_end_to_end(tmp_path, capsys):
     agent.memory.add_semantic("the sky is blue")
     agent.memory.add_procedural("open the door by turning the knob")
     resp = agent.receive("cats like milk")
-    assert "cats" in resp
+    assert isinstance(resp, str) and resp
 
     retriever = Retriever(
         agent.memory.all(),


### PR DESCRIPTION
## Summary
- simplify `LocalLLM` response
- return static strings when cloud LLMs aren't available
- update end-to-end tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c086f7208322aa2320124c4a7e39