### PR TITLE
Fix missing QListWidget import

### DIFF
--- a/gui/qt_interface.py
+++ b/gui/qt_interface.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QSplitter,
     QSizePolicy,
     QDialog,
+    QListWidget,
 )
 from PyQt5.QtCore import Qt, QTimer
 import sys


### PR DESCRIPTION
## Summary
- import `QListWidget` in `qt_interface`
- keep tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c741afc48322b94f9aaa27f45845