### PR TITLE
Track latest dream in GUI timer

### DIFF
--- a/gui/qt_interface.py
+++ b/gui/qt_interface.py
@@ -97,6 +97,7 @@ class MemorySystemGUI(QWidget):
     def __init__(self, agent):
         super().__init__()
         self.agent = agent
+        self._last_dream: str | None = None
         self.init_ui()
 
     def init_ui(self):
@@ -129,6 +130,15 @@ class MemorySystemGUI(QWidget):
         self.dream_box = QTextEdit()
         self.dream_box.setReadOnly(True)
         right_panel.addWidget(self.dream_box)
+        if self.agent:
+            dream_entries = [
+                m.content
+                for m in self.agent.memory.all()
+                if m.content.startswith("Dream:")
+            ]
+            if dream_entries:
+                self._last_dream = dream_entries[-1]
+                self.dream_box.setPlainText(self._last_dream)
 
         right_panel.addWidget(QLabel("Next Dream"))
         self.countdown_label = QLabel("")
@@ -202,6 +212,17 @@ class MemorySystemGUI(QWidget):
         else:
             self.countdown_label.setText(f"{int(remaining)}s")
 
+        dream_entries = [
+            m.content
+            for m in self.agent.memory.all()
+            if m.content.startswith("Dream:")
+        ]
+        if dream_entries:
+            latest = dream_entries[-1]
+            if latest != self._last_dream:
+                self._last_dream = latest
+                self.dream_box.setPlainText(latest)
+
     def show_memories(self):
         if not self.agent:
             return
@@ -258,6 +279,8 @@ class MemorySystemGUI(QWidget):
         self.memory_box.setPlainText(mem_text)
         self.mood_box.setPlainText(mood)
         self.dream_box.setPlainText(dreaming)
+        if dreaming:
+            self._last_dream = dreaming
 
 def run_gui(agent=None):
     """Launch the Qt GUI and return when the window is closed."""

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -66,3 +66,27 @@ def test_memory_browser_edit_refreshes_tags(tmp_path):
     assert manager.working.contents()[0].metadata.get("tags") == ["animal"]
 
     app.quit()
+
+
+def test_update_countdown_refreshes_dream_box():
+    app = QApplication.instance() or QApplication([])
+
+    entries = [
+        MemoryEntry(content="Dream: first", embedding=[], timestamp=datetime.utcnow())
+    ]
+
+    mock_agent = MagicMock()
+    mock_agent.memory.all.return_value = entries
+    mock_agent.memory.time_until_dream.return_value = 10
+
+    gui = MemorySystemGUI(mock_agent)
+
+    # Simulate new dream added to memory
+    entries.append(MemoryEntry(content="Dream: second", embedding=[], timestamp=datetime.utcnow()))
+
+    gui.update_countdown()
+
+    assert "Dream: second" in gui.dream_box.toPlainText()
+    assert gui.countdown_label.text() == "10s"
+
+    app.quit()


### PR DESCRIPTION
## Summary
- track the most recent dream entry in the GUI
- update dream box when a new dream appears
- test timer update logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cd831f8483228399a1089948f7f6