### PR TITLE
Fix tagging tokenizer independence

### DIFF
--- a/encoding/tagging.py
+++ b/encoding/tagging.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from typing import List
-
-from encoding.encoder import encode_text
+import re
 
 # Simple mapping of categories to keyword sets
 _TAG_VOCAB = {
@@ -16,7 +15,7 @@ _TAG_VOCAB = {
 
 def tag_text(text: str) -> List[str]:
     """Return list of tags detected in text based on keyword matches."""
-    tokens = set(encode_text(text))
+    tokens = set(re.findall(r"\w+", text.lower()))
     tags = [name for name, words in _TAG_VOCAB.items() if tokens & words]
     if not tags:
         tags.append("misc")

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli import memory_cli
+from storage.db_interface import Database
+
+
+def test_tagging_with_float_embeddings(tmp_path):
+    db = Database(tmp_path / "mem.db")
+    with patch("cli.memory_cli.encode_text", return_value=[0.1, 0.2, 0.3]):
+        memory_cli.add_memory(db, "hello cat")
+    stored = db.load_all()[0]
+    assert set(stored.metadata.get("tags")) == {"animal", "greeting"}


### PR DESCRIPTION
## Summary
- ensure `tag_text` does not rely on `encode_text`
- tokenize with regex so tags work regardless of sentence-transformers
- add regression test verifying tags when embeddings are floats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dc91c4308322b2208cfcb395a7db