### PR TITLE
Fix scheduler thread cleanup

### DIFF
--- a/ms_utils/scheduler.py
+++ b/ms_utils/scheduler.py
@@ -30,7 +30,8 @@ class Scheduler:
         """Stop all scheduled tasks."""
         self._stop.set()
         for t in list(self._threads):
-            t.join(timeout=0)
+            t.join()
+        self._threads.clear()
 
 
 __all__ = ["Scheduler"]


### PR DESCRIPTION
## Summary
- ensure scheduler threads fully stop by joining each with no timeout
- clear thread list after stopping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ddacdd388322a0e411daca637202