### PR TITLE
Persist dream summaries to semantic DB

### DIFF
--- a/dreaming/dream_engine.py
+++ b/dreaming/dream_engine.py
@@ -26,6 +26,7 @@ class DreamEngine:
         *,
         llm_name: str = "local",
         semantic: SemanticMemory | None = None,
+        manager: "MemoryManager" | None = None,
         log: bool = False,
     ) -> str:
         """Return a concise dream summary using the configured LLM.
@@ -38,6 +39,9 @@ class DreamEngine:
             Identifier of the LLM backend to use.
         semantic:
             Optional semantic memory store to persist the summary.
+        manager:
+            If provided along with ``semantic``, ``manager.add_semantic`` will be
+            called so the summary is saved to persistent storage.
         log:
             If ``True``, log the produced summary using :class:`ms_utils.logger.Logger`.
         """
@@ -51,7 +55,10 @@ class DreamEngine:
         summary = llm.generate(prompt).strip()
         summary = "Dream: " + summary
         if semantic is not None:
-            semantic.add(summary)
+            if manager is not None:
+                manager.add_semantic(summary)
+            else:
+                semantic.add(summary)
         if log:
             logger.info(summary)
         return summary
@@ -90,6 +97,7 @@ class DreamEngine:
                     recent,
                     llm_name=llm_name,
                     semantic=manager.semantic if store_semantic else None,
+                    manager=manager if store_semantic else None,
                     log=False,
                 )
                 manager.add(summary)

--- a/tests/test_dreaming_scheduler.py
+++ b/tests/test_dreaming_scheduler.py
@@ -8,8 +8,9 @@ from core.memory_manager import MemoryManager
 from dreaming.dream_engine import DreamEngine
 
 
-def test_dream_run_summarizes_and_prunes():
-    manager = MemoryManager(db_path=":memory:")
+def test_dream_run_summarizes_and_prunes(tmp_path):
+    path = tmp_path / "mem.db"
+    manager = MemoryManager(db_path=path)
     for i in range(7):
         manager.add(f"event {i}")
 
@@ -35,6 +36,10 @@ def test_dream_run_summarizes_and_prunes():
     assert len(mems) == 5
     assert any("Dream:" in m.content for m in mems)
     assert manager.semantic.all()
+
+    reloaded = MemoryManager(db_path=path)
+    sem_entries = [m.content for m in reloaded.semantic.all()]
+    assert any("Dream:" in s for s in sem_entries)
 
 
 def test_manager_start_dreaming_uses_engine():


### PR DESCRIPTION
## Summary
- ensure dream summaries saved to semantic memory persist via `manager.add_semantic`
- verify summaries end up in semantic storage on disk

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841de3df7408322ad25d57ced9ebe82