### PR TITLE
Add thinking scheduler to memory manager

### DIFF
--- a/tests/test_thinking_engine.py
+++ b/tests/test_thinking_engine.py
@@ -36,3 +36,13 @@ def test_run_invokes_think_once(tmp_path):
             sched = engine.run(manager, interval=0.1)
     assert isinstance(sched, Scheduler)
     assert mock_once.called
+
+
+def test_manager_start_thinking_uses_engine():
+    manager = MemoryManager(db_path=":memory:")
+
+    with patch.object(ThinkingEngine, "run", return_value=None) as mock_run:
+        manager.start_thinking(interval=1, llm_name="openai")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("llm_name") == "openai"


### PR DESCRIPTION
## Summary
- add ThinkingEngine support to MemoryManager
- expose methods to start/stop thinking and check remaining time
- test thinking scheduler integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e8bf18508322adce999d3a38803e