### PR TITLE
Add cognitive scheduler

### DIFF
--- a/core/cognitive_scheduler.py
+++ b/core/cognitive_scheduler.py
@@ -1,0 +1,100 @@
+"""Idle-based cognitive state manager."""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from ms_utils.scheduler import Scheduler
+from typing import Optional
+
+from core.memory_manager import MemoryManager
+
+
+class CognitiveState(Enum):
+    """Possible cognitive states."""
+
+    ACTIVE = "Active"
+    REFLECTIVE = "Reflective"
+    ASLEEP = "Asleep"
+
+
+class CognitiveScheduler:
+    """Transition between thinking and dreaming based on idle time."""
+
+    def __init__(
+        self,
+        manager: MemoryManager,
+        *,
+        T_think: float = 60.0,
+        T_dream: float = 300.0,
+        T_alarm: float = 1200.0,
+    ) -> None:
+        self.manager = manager
+        self.T_think = T_think
+        self.T_dream = T_dream
+        self.T_alarm = T_alarm
+        self.state = CognitiveState.ACTIVE
+        self.last_input = time.monotonic()
+        self.state_start = self.last_input
+        self._think_sched: Optional[Scheduler] = None
+        self._dream_sched: Optional[Scheduler] = None
+
+    def notify_input(self) -> None:
+        """Record user activity and wake the system if needed."""
+        self.last_input = time.monotonic()
+        self.state_start = self.last_input
+        if self.state != CognitiveState.ACTIVE:
+            self._stop_engines()
+            self.state = CognitiveState.ACTIVE
+
+    def current_state(self) -> CognitiveState:
+        """Return the current cognitive state."""
+        return self.state
+
+    def run(self, interval: float = 1.0) -> Scheduler:
+        """Start periodic state checks."""
+        sched = Scheduler()
+        sched.schedule(interval, self.check)
+        return sched
+
+    def check(self) -> None:
+        """Evaluate idle time and update cognitive state."""
+        now = time.monotonic()
+        idle = now - self.last_input
+
+        if self.state == CognitiveState.ACTIVE:
+            if idle >= self.T_dream:
+                self.state = CognitiveState.ASLEEP
+                self.state_start = now
+                self._dream_sched = self.manager.start_dreaming()
+            elif idle >= self.T_think:
+                self.state = CognitiveState.REFLECTIVE
+                self.state_start = now
+                self._think_sched = self.manager.start_thinking()
+        elif self.state == CognitiveState.REFLECTIVE:
+            if idle >= self.T_dream:
+                if self._think_sched:
+                    self.manager.stop_thinking()
+                    self._think_sched = None
+                self.state = CognitiveState.ASLEEP
+                self.state_start = now
+                self._dream_sched = self.manager.start_dreaming()
+        elif self.state == CognitiveState.ASLEEP:
+            if now - self.state_start >= self.T_alarm:
+                if self._dream_sched:
+                    self.manager.stop_dreaming()
+                    self._dream_sched = None
+                self.last_input = now
+                self.state = CognitiveState.ACTIVE
+                self.state_start = now
+
+    def _stop_engines(self) -> None:
+        if self._think_sched:
+            self.manager.stop_thinking()
+            self._think_sched = None
+        if self._dream_sched:
+            self.manager.stop_dreaming()
+            self._dream_sched = None
+
+
+__all__ = ["CognitiveScheduler", "CognitiveState"]

--- a/docs/cognitive_scheduler.md
+++ b/docs/cognitive_scheduler.md
@@ -1,0 +1,13 @@
+# Cognitive Scheduler
+
+The cognitive scheduler monitors idle time to drive the agent's internal
+processes. It keeps track of the last user interaction and switches between
+three states:
+
+- **Active** – recent user input, no background tasks
+- **Reflective** – idle for `T_think` seconds, starts the ThinkingEngine
+- **Asleep** – idle for `T_dream` seconds, starts the DreamEngine
+
+Dreaming is automatically stopped after `T_alarm` seconds to prevent endless
+sleep. Any user activity immediately wakes the scheduler and cancels running
+engines.

--- a/tests/test_cognitive_scheduler.py
+++ b/tests/test_cognitive_scheduler.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+import time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.memory_manager import MemoryManager
+from core.cognitive_scheduler import CognitiveScheduler, CognitiveState
+
+
+def test_state_transitions(monkeypatch):
+    mm = MemoryManager(db_path=":memory:")
+    times = iter([0, 11, 21, 25, 26])
+    monkeypatch.setattr(time, "monotonic", lambda: next(times))
+    sched = CognitiveScheduler(mm, T_think=10, T_dream=20, T_alarm=60)
+
+    start_think = MagicMock()
+    start_dream = MagicMock()
+    stop_think = MagicMock()
+    stop_dream = MagicMock()
+    monkeypatch.setattr(mm, "start_thinking", start_think)
+    monkeypatch.setattr(mm, "start_dreaming", start_dream)
+    monkeypatch.setattr(mm, "stop_thinking", stop_think)
+    monkeypatch.setattr(mm, "stop_dreaming", stop_dream)
+
+    sched.check()
+    assert sched.current_state() is CognitiveState.REFLECTIVE
+    assert start_think.called
+
+    sched.check()
+    assert sched.current_state() is CognitiveState.ASLEEP
+    assert start_dream.called
+    assert stop_think.called
+
+    sched.notify_input()
+    assert stop_dream.called
+    assert sched.current_state() is CognitiveState.ACTIVE
+
+    sched.check()
+    assert sched.current_state() is CognitiveState.ACTIVE
+
+
+def test_alarm_wakes(monkeypatch):
+    mm = MemoryManager(db_path=":memory:")
+    times = iter([0, 5, 11, 12])
+    monkeypatch.setattr(time, "monotonic", lambda: next(times))
+    sched = CognitiveScheduler(mm, T_think=2, T_dream=4, T_alarm=6)
+
+    monkeypatch.setattr(mm, "start_dreaming", MagicMock())
+    stop_dream = MagicMock()
+    monkeypatch.setattr(mm, "stop_dreaming", stop_dream)
+    monkeypatch.setattr(mm, "start_thinking", MagicMock())
+    monkeypatch.setattr(mm, "stop_thinking", MagicMock())
+
+    sched.check()
+    assert sched.current_state() is CognitiveState.ASLEEP
+
+    sched.check()
+    assert sched.current_state() is CognitiveState.ACTIVE
+    assert stop_dream.called
+
+    sched.check()
+    assert sched.current_state() is CognitiveState.ACTIVE


### PR DESCRIPTION
## Summary
- add cognitive state manager that drives thinking and dreaming based on idle time
- document the scheduler
- test transitions and alarm logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e9e83ae48322ad7d728e669966f4