### PR TITLE
Add reasoning engine

### DIFF
--- a/docs/reasoning_engine.md
+++ b/docs/reasoning_engine.md
@@ -1,0 +1,14 @@
+# ReasoningEngine Overview
+
+The `reasoning.reasoning_engine` module provides a small utility class for
+autonomous reasoning and planning.  It queries episodic, semantic and
+procedural memories, reconstructs a context and prompts the configured LLM
+for a multi-step analysis or a plan.
+
+- `ReasoningEngine.reason_once` performs one reasoning cycle about a topic and
+  stores the result in episodic memory tagged `reasoning`.
+- `ReasoningEngine.plan` creates a step-by-step plan for a goal and stores the
+  plan in procedural memory tagged `plan`.
+
+Both operations log prompts, retrieved memory identifiers and outputs via
+`ms_utils.logger.Logger`.

--- a/reasoning/__init__.py
+++ b/reasoning/__init__.py
@@ -1,0 +1,3 @@
+from .reasoning_engine import ReasoningEngine
+
+__all__ = ["ReasoningEngine"]

--- a/reasoning/reasoning_engine.py
+++ b/reasoning/reasoning_engine.py
@@ -1,0 +1,127 @@
+"""Reasoning and planning utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, TYPE_CHECKING
+
+from retrieval.cue_builder import build_cue
+from retrieval.retriever import Retriever
+from reconstruction.reconstructor import Reconstructor
+from llm import llm_router
+from ms_utils.logger import Logger
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from core.memory_manager import MemoryManager
+    from core.memory_entry import MemoryEntry
+
+
+logger = Logger(__name__)
+
+
+class ReasoningEngine:
+    """Perform multi-step reasoning and planning using stored memories."""
+
+    def reason_once(
+        self,
+        manager: "MemoryManager",
+        topic: str,
+        llm_name: str = "local",
+    ) -> str:
+        """Generate a reasoning chain about ``topic``.
+
+        Parameters
+        ----------
+        manager:
+            Memory manager providing access to memories.
+        topic:
+            Topic or question to reason about.
+        llm_name:
+            Name of the LLM backend to use.
+
+        Returns
+        -------
+        str
+            The reasoning output from the LLM.
+        """
+        cue = build_cue(topic)
+        retriever = Retriever(
+            manager.all(),
+            semantic=manager.semantic.all(),
+            procedural=manager.procedural.all(),
+        )
+        memories = retriever.query(cue, top_k=5)
+        logger.info("Retrieved: " + ", ".join(str(m.timestamp) for m in memories))
+        reconstructor = Reconstructor()
+        context = reconstructor.build_context(memories)
+        prompt = (
+            f"{context}\nReason step by step about: {topic}" if context else f"Reason step by step about: {topic}"
+        )
+        llm = llm_router.get_llm(llm_name)
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You reason about your experiences. Respond with a concise multi-step analysis."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+        logger.info("Prompt: " + prompt)
+        output = llm.generate(messages).strip()
+        logger.info("Output: " + output)
+        entry = manager.add(
+            output,
+            metadata={"topic": topic, "tags": ["reasoning", "inference"]},
+        )
+        logger.info(f"Stored reasoning memory {entry.timestamp.isoformat()}")
+        return output
+
+    def plan(
+        self,
+        goal: str,
+        manager: "MemoryManager",
+        llm_name: str = "local",
+    ) -> str:
+        """Create a step-by-step plan to achieve ``goal``.
+
+        The resulting plan is stored in procedural memory tagged ``plan``.
+        """
+        cue = build_cue(goal)
+        retriever = Retriever(
+            manager.all(),
+            semantic=manager.semantic.all(),
+            procedural=manager.procedural.all(),
+        )
+        memories = retriever.query(cue, top_k=5)
+        reconstructor = Reconstructor()
+        context = reconstructor.build_context(memories)
+        prompt = (
+            f"{context}\nCreate a plan to accomplish: {goal}" if context else f"Create a plan to accomplish: {goal}"
+        )
+        llm = llm_router.get_llm(llm_name)
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a planner. Provide a short numbered plan to achieve the goal."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+        logger.info("Plan prompt: " + prompt)
+        plan_text = llm.generate(messages).strip()
+        logger.info("Plan output: " + plan_text)
+        entry = manager.add_procedural(
+            plan_text,
+            metadata={"goal": goal, "tags": ["reasoning", "plan"]},
+        )
+        logger.info(f"Stored plan memory {entry.timestamp.isoformat()}")
+        return plan_text
+
+    def analyze_contradictions(self, text: str) -> dict[str, float]:
+        """Placeholder for contradiction analysis of ``text``."""
+        # Future work: implement real contradiction detection
+        return {}
+
+
+__all__ = ["ReasoningEngine"]

--- a/tests/test_reasoning_engine.py
+++ b/tests/test_reasoning_engine.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.memory_manager import MemoryManager
+from reasoning.reasoning_engine import ReasoningEngine
+
+
+def test_reason_once_stores_reasoning():
+    manager = MemoryManager(db_path=":memory:")
+    engine = ReasoningEngine()
+    with patch("reasoning.reasoning_engine.llm_router.get_llm") as mock_get, \
+            patch("retrieval.cue_builder.build_cue", return_value="cue"), \
+            patch("retrieval.retriever.Retriever.query", return_value=[]), \
+            patch("reconstruction.reconstructor.Reconstructor.build_context", return_value=""):
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = "analysis"
+        mock_get.return_value = mock_llm
+        result = engine.reason_once(manager, "topic")
+    assert result == "analysis"
+    entry = manager.all()[-1]
+    assert entry.content == "analysis"
+    assert "reasoning" in entry.metadata.get("tags", [])
+
+
+def test_plan_stores_procedural():
+    manager = MemoryManager(db_path=":memory:")
+    engine = ReasoningEngine()
+    with patch("reasoning.reasoning_engine.llm_router.get_llm") as mock_get, \
+            patch("retrieval.cue_builder.build_cue", return_value="cue"), \
+            patch("retrieval.retriever.Retriever.query", return_value=[]), \
+            patch("reconstruction.reconstructor.Reconstructor.build_context", return_value=""), \
+            patch.object(manager, "add_procedural") as mock_add:
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = "steps"
+        mock_get.return_value = mock_llm
+        plan = engine.plan("goal", manager)
+        mock_add.assert_called_once()
+        args, kwargs = mock_add.call_args
+        assert "plan" in kwargs.get("metadata", {}).get("tags", [])
+    assert plan == "steps"


### PR DESCRIPTION
## Summary
- implement `ReasoningEngine` for multi-step reasoning and planning
- document reasoning engine usage
- test reasoning engine behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d048b53c08322bfa3e9778f69eeec