### PR TITLE
Enable reasoning config

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -3,3 +3,6 @@ memory:
   working_size: 10
 reconstruction:
   max_context_length: 1000
+reasoning:
+  enabled: true
+  depth: 3

--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -216,6 +216,8 @@ class MemoryManager:
         *,
         interval: float = 60.0,
         llm_name: str = "local",
+        use_reasoning: bool | None = None,
+        reasoning_depth: int | None = None,
     ) -> Scheduler:
         """Start periodic introspective thinking via :class:`ThinkingEngine`.
 
@@ -226,11 +228,20 @@ class MemoryManager:
         # Cancel an existing dreaming loop if present
         self.stop_dreaming()
 
+        cfg = _load_config()
+        r_cfg = cfg.get("reasoning", {})
+        if use_reasoning is None:
+            use_reasoning = r_cfg.get("enabled", False)
+        if reasoning_depth is None:
+            reasoning_depth = r_cfg.get("depth", 1)
+
         engine = ThinkingEngine()
         self._think_scheduler = engine.run(
             self,
             interval=interval,
             llm_name=llm_name,
+            use_reasoning=use_reasoning,
+            reasoning_depth=reasoning_depth,
         )
         self._think_interval = interval
         self._next_think_time = time.monotonic() + interval

--- a/docs/reasoning_engine.md
+++ b/docs/reasoning_engine.md
@@ -13,3 +13,18 @@ The `ReasoningEngine` performs explicit chain-of-thought reasoning and planning 
 
 ## Logging and Tagging
 All prompts, retrieved memory identifiers and LLM outputs are logged via `ms_utils.logger.Logger`. Resulting memory entries are tagged `reasoning`, `inference` or `plan` for later retrieval and analysis.
+
+## Configuration
+
+Reasoning behavior is controlled by the `reasoning` section in
+`config/default_config.yaml`:
+
+```yaml
+reasoning:
+  enabled: true        # enable reasoning during thinking cycles
+  depth: 3             # number of reasoning steps to request
+```
+
+When `MemoryManager.start_thinking` is called without explicit options, these
+values determine whether the `ReasoningEngine` is invoked and how many steps it
+should request from the LLM.

--- a/reasoning/reasoning_engine.py
+++ b/reasoning/reasoning_engine.py
@@ -26,6 +26,7 @@ class ReasoningEngine:
         manager: "MemoryManager",
         topic: str,
         llm_name: str = "local",
+        depth: int = 1,
     ) -> str:
         """Generate a reasoning chain about ``topic``.
 
@@ -37,6 +38,8 @@ class ReasoningEngine:
             Topic or question to reason about.
         llm_name:
             Name of the LLM backend to use.
+        depth:
+            Desired number of reasoning steps.
 
         Returns
         -------
@@ -54,7 +57,7 @@ class ReasoningEngine:
         reconstructor = Reconstructor()
         context = reconstructor.build_context(memories)
         prompt = (
-            f"{context}\nReason step by step about: {topic}" if context else f"Reason step by step about: {topic}"
+            f"{context}\nReason in {depth} steps about: {topic}" if context else f"Reason in {depth} steps about: {topic}"
         )
         llm = llm_router.get_llm(llm_name)
         messages = [

--- a/tests/test_config_reasoning.py
+++ b/tests/test_config_reasoning.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.memory_manager import MemoryManager
+from thinking.thinking_engine import ThinkingEngine
+
+
+def test_start_thinking_uses_reasoning_config(monkeypatch):
+    monkeypatch.setattr(
+        "core.memory_manager._load_config",
+        lambda: {
+            "memory": {"working_size": 10},
+            "reasoning": {"enabled": True, "depth": 2},
+        },
+    )
+
+    manager = MemoryManager(db_path=":memory:")
+    with patch.object(ThinkingEngine, "run", return_value=None) as mock_run:
+        manager.start_thinking(interval=1)
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("use_reasoning") is True
+        assert kwargs.get("reasoning_depth") == 2
+

--- a/thinking/thinking_engine.py
+++ b/thinking/thinking_engine.py
@@ -43,6 +43,7 @@ class ThinkingEngine:
         mood: str,
         llm_name: str = "local",
         use_reasoning: bool = False,
+        reasoning_depth: int = 1,
     ) -> str:
         """Generate one introspective thought.
 
@@ -57,6 +58,8 @@ class ThinkingEngine:
         use_reasoning:
             If ``True``, generate an additional reasoning step about the
             produced thought.
+        reasoning_depth:
+            Number of steps to pass to :class:`ReasoningEngine`.
 
         Returns
         -------
@@ -97,7 +100,9 @@ class ThinkingEngine:
         )
         if use_reasoning:
             reasoning_engine = ReasoningEngine()
-            reasoning_engine.reason_once(manager, thought, llm_name=llm_name)
+            reasoning_engine.reason_once(
+                manager, thought, llm_name=llm_name, depth=reasoning_depth
+            )
         return thought
 
     def run(
@@ -107,6 +112,7 @@ class ThinkingEngine:
         interval: float = 60.0,
         llm_name: str = "local",
         use_reasoning: bool = False,
+        reasoning_depth: int = 1,
     ) -> Scheduler:
         """Start periodic background thinking.
 
@@ -121,6 +127,8 @@ class ThinkingEngine:
         use_reasoning:
             If ``True``, run :meth:`ReasoningEngine.reason_once` after each
             introspective thought.
+        reasoning_depth:
+            Number of reasoning steps for ``ReasoningEngine``.
 
         Returns
         -------
@@ -142,6 +150,7 @@ class ThinkingEngine:
                 mood,
                 llm_name=llm_name,
                 use_reasoning=use_reasoning,
+                reasoning_depth=reasoning_depth,
             )
             manager._next_think_time = time.monotonic() + interval
 


### PR DESCRIPTION
## Summary
- extend default configuration with reasoning settings
- wire reasoning options into `MemoryManager.start_thinking`
- allow ThinkingEngine and ReasoningEngine to accept reasoning depth
- document reasoning configuration
- test reading reasoning configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d07086e648322aa934fce970650bd