### PR TITLE
Add duration-based thinking and dreaming

### DIFF
--- a/docs/cognitive_scheduler.md
+++ b/docs/cognitive_scheduler.md
@@ -5,8 +5,8 @@ processes. It keeps track of the last user interaction and switches between
 three states:
 
 - **Active** – recent user input, no background tasks
-- **Reflective** – idle for `T_think` seconds, starts the ThinkingEngine
-- **Asleep** – idle for `T_dream` seconds, starts the DreamEngine
+- **Reflective** – after `T_think` seconds of inactivity the agent thinks for that duration
+- **Asleep** – once reflection ends the agent dreams for `T_dream` seconds
 
 Dreaming is automatically stopped after `T_alarm` seconds to prevent endless
 sleep. Any user activity immediately wakes the scheduler and cancels running

--- a/docs/gui_settings.md
+++ b/docs/gui_settings.md
@@ -8,8 +8,8 @@ Use the *Settings* action in the window's menu bar to open the dialog. Older
 versions exposed a separate button on the side panel. The
 fields correspond to:
 
-- `T_think` – seconds of inactivity before background thinking starts.
-- `T_dream` – idle time before the DreamEngine is triggered.
+- `T_think` – how long the agent remains reflective once thinking begins.
+- `T_dream` – duration of the dreaming state before waking.
 - `T_alarm` – maximum duration of dreaming before waking automatically.
 - `LLM backend` – selects which language model implementation to use.
 - `Database file` – location of the SQLite memory store.
@@ -17,9 +17,9 @@ fields correspond to:
   backend. Set the value to `0` to wait indefinitely. This option only appears
   when the active LLM is LMStudio.
 
-`T_think` and `T_dream` also determine how frequently the thinking and dreaming
-engines run once started. Lower values result in more frequent background
-updates.
+`T_think` and `T_dream` specify how long the agent remains in each state when
+no user input is received. Lower values lead to shorter reflection and dreaming
+periods before transitioning.
 
 Changes are applied immediately to the attached scheduler and any running
 background tasks are restarted. When using the LMStudio backend, the timeout

--- a/docs/thinking_engine.md
+++ b/docs/thinking_engine.md
@@ -65,8 +65,8 @@ The ThinkingEngine and DreamEngine coordinate via a cognitive activity cycle bas
 | State | Trigger Condition | Action Initiated | Notes |
 |-------|------------------|-----------------|-------|
 | Active | Any user input | Normal behavior; thinking and dreaming paused | |
-| Reflective | No input for `T_think` seconds | Start ThinkingEngine | May loop through multiple thoughts |
-| Asleep | No input for `T_dream` > `T_think` | Start DreamEngine | Ends with alarm or stimulus |
+| Reflective | Idle for `T_think` seconds | Think for `T_think` seconds | May loop through multiple thoughts |
+| Asleep | Reflection period ended | Dream for `T_dream` seconds | Ends with alarm or stimulus |
 | Interrupted | Any input during reflection or dreaming | Wake agent, cancel tasks | May log partial output |
 | Alarmed | Max sleep duration (`T_alarm`) exceeded | Automatically awaken | Prevents excessive dreaming |
 


### PR DESCRIPTION
## Summary
- support duration in `ThinkingEngine.run` and `DreamEngine.run`
- manage end times in `MemoryManager` and expose through helpers
- treat `T_think` and `T_dream` as state durations in `CognitiveScheduler`
- update unit tests for duration behavior
- document new scheduler semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0951587c832292ade41446ed7db4