### PR TITLE
Fix scheduler start for thinking and dreaming

### DIFF
--- a/dreaming/dream_engine.py
+++ b/dreaming/dream_engine.py
@@ -130,6 +130,8 @@ class DreamEngine:
             manager.prune(max_entries)
             manager._next_dream_time = time.monotonic() + interval
 
+        # ensure the first summary occurs even when duration == interval
+        _task()
         scheduler.schedule(interval, _task)
 
         if duration is not None:

--- a/tests/test_dreaming_scheduler.py
+++ b/tests/test_dreaming_scheduler.py
@@ -45,6 +45,19 @@ def test_dream_run_summarizes_and_prunes(tmp_path):
     assert any("Dream:" in s for s in sem_entries)
 
 
+def test_dream_run_executes_without_scheduler(tmp_path):
+    manager = MemoryManager(db_path=tmp_path / "mem.db")
+    for i in range(3):
+        manager.add(f"event {i}")
+
+    with patch("ms_utils.scheduler.Scheduler.schedule", lambda *a, **k: None), \
+            patch.object(DreamEngine, "summarize", return_value=("d", [], {})) as mock_sum:
+        engine = DreamEngine()
+        engine.run(manager, interval=0.1, duration=0.1)
+
+    assert mock_sum.called
+
+
 def test_dream_run_stops_after_duration(tmp_path):
     manager = MemoryManager(db_path=tmp_path / "mem.db")
     engine = DreamEngine()

--- a/tests/test_thinking_engine.py
+++ b/tests/test_thinking_engine.py
@@ -41,6 +41,16 @@ def test_run_invokes_think_once(tmp_path):
     assert mock_once.called
 
 
+def test_run_executes_without_scheduler(tmp_path):
+    manager = MemoryManager(db_path=tmp_path / "mem.db")
+    engine = ThinkingEngine(prompts=["reflect"])
+
+    with patch("ms_utils.scheduler.Scheduler.schedule", lambda *a, **k: None):
+        with patch.object(engine, "think_once", return_value="x") as mock_once:
+            engine.run(manager, interval=0.1, duration=0.1)
+    assert mock_once.called
+
+
 def test_run_stops_after_duration(tmp_path):
     manager = MemoryManager(db_path=tmp_path / "mem.db")
     engine = ThinkingEngine(prompts=["reflect"])

--- a/thinking/thinking_engine.py
+++ b/thinking/thinking_engine.py
@@ -162,6 +162,8 @@ class ThinkingEngine:
             )
             manager._next_think_time = time.monotonic() + interval
 
+        # run once immediately so a thought occurs even if duration == interval
+        _task()
         scheduler.schedule(interval, _task)
 
         if duration is not None:


### PR DESCRIPTION
## Summary
- run thinking and dreaming tasks immediately before scheduling recurring work
- test that engines execute at least once even if the scheduler does nothing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d15b6cf8483228e3ce40ff0fedc56