### PR TITLE
Add think_interval for repeated thinking

### DIFF
--- a/cli/memory_cli.py
+++ b/cli/memory_cli.py
@@ -289,7 +289,7 @@ def start_think(
     llm_name: str = "local",
 ) -> None:
     """Begin periodic thinking using ``MemoryManager`` and block until interrupted."""
-    scheduler = manager.start_thinking(interval=interval, llm_name=llm_name)
+    scheduler = manager.start_thinking(think_interval=interval, llm_name=llm_name)
     logger.info("Thinking started. Press Ctrl+C to stop.")
     try:
         while True:

--- a/core/cognitive_scheduler.py
+++ b/core/cognitive_scheduler.py
@@ -29,6 +29,7 @@ class CognitiveScheduler:
         T_think: float = 60.0,
         T_dream: float = 300.0,
         T_alarm: float = 1200.0,
+        think_interval: float | None = None,
     ) -> None:
         """Create a scheduler for ``manager`` using ``llm_name`` for background tasks.
 
@@ -44,6 +45,8 @@ class CognitiveScheduler:
             Duration in seconds to remain asleep and dreaming.
         T_alarm:
             Maximum sleep duration before automatically waking.
+        think_interval:
+            Seconds between reflective thoughts while in the reflective state.
         """
 
         self.manager = manager
@@ -51,6 +54,7 @@ class CognitiveScheduler:
         self.T_think = T_think
         self.T_dream = T_dream
         self.T_alarm = T_alarm
+        self.think_interval = think_interval if think_interval is not None else T_think
         self.state = CognitiveState.ACTIVE
         self.last_input = time.monotonic()
         self.state_start = self.last_input
@@ -85,7 +89,7 @@ class CognitiveScheduler:
                 self.state = CognitiveState.REFLECTIVE
                 self.state_start = now
                 self._think_sched = self.manager.start_thinking(
-                    interval=self.T_think,
+                    think_interval=self.think_interval,
                     duration=self.T_think,
                     llm_name=self.llm_name,
                 )

--- a/core/memory_manager.py
+++ b/core/memory_manager.py
@@ -229,7 +229,7 @@ class MemoryManager:
     def start_thinking(
         self,
         *,
-        interval: float = 60.0,
+        think_interval: float = 60.0,
         duration: float | None = None,
         llm_name: str = "local",
         use_reasoning: bool | None = None,
@@ -239,7 +239,9 @@ class MemoryManager:
 
         Any active dreaming scheduler will be automatically cancelled before
         launching a new thinking task. The ``duration`` parameter controls how
-        long the thinking loop runs before it automatically stops.
+        long the thinking loop runs before it automatically stops. The
+        ``think_interval`` parameter determines how frequently thoughts are
+        generated during this period.
         """
 
         # Cancel an existing dreaming loop if present
@@ -255,15 +257,15 @@ class MemoryManager:
         engine = ThinkingEngine()
         self._think_scheduler = engine.run(
             self,
-            interval=interval,
+            think_interval=think_interval,
             duration=duration,
             llm_name=llm_name,
             use_reasoning=use_reasoning,
             reasoning_depth=reasoning_depth,
         )
-        self._think_interval = interval
+        self._think_interval = think_interval
         now = time.monotonic()
-        self._next_think_time = now + interval
+        self._next_think_time = now + think_interval
         self._think_end_time = now + duration if duration is not None else None
         return self._think_scheduler
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -168,7 +168,7 @@ def test_start_and_stop_thinking(monkeypatch):
     monkeypatch.setattr(memory_cli.time, "sleep", lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
     memory_cli.start_think(manager, interval=5)
 
-    manager.start_thinking.assert_called_once_with(interval=5, llm_name="local")
+    manager.start_thinking.assert_called_once_with(think_interval=5, llm_name="local")
     scheduler.stop.assert_called_once()
     memory_cli.stop_think(manager)
     manager.stop_thinking.assert_called_once()

--- a/tests/test_cognitive_scheduler.py
+++ b/tests/test_cognitive_scheduler.py
@@ -13,7 +13,7 @@ def test_state_transitions(monkeypatch):
     mm = MemoryManager(db_path=":memory:")
     times = iter([0, 11, 21, 25, 26])
     monkeypatch.setattr(time, "monotonic", lambda: next(times))
-    sched = CognitiveScheduler(mm, T_think=10, T_dream=20, T_alarm=60)
+    sched = CognitiveScheduler(mm, T_think=10, T_dream=20, T_alarm=60, think_interval=5)
 
     start_think = MagicMock()
     start_dream = MagicMock()
@@ -27,7 +27,7 @@ def test_state_transitions(monkeypatch):
     sched.check()
     assert sched.current_state() is CognitiveState.REFLECTIVE
     start_think.assert_called_once()
-    assert start_think.call_args.kwargs.get("interval") == 10
+    assert start_think.call_args.kwargs.get("think_interval") == 5
     assert start_think.call_args.kwargs.get("duration") == 10
 
     sched.check()
@@ -49,7 +49,7 @@ def test_alarm_wakes(monkeypatch):
     mm = MemoryManager(db_path=":memory:")
     times = iter([0, 3, 7, 13, 14])
     monkeypatch.setattr(time, "monotonic", lambda: next(times))
-    sched = CognitiveScheduler(mm, T_think=2, T_dream=4, T_alarm=6)
+    sched = CognitiveScheduler(mm, T_think=2, T_dream=4, T_alarm=6, think_interval=1)
 
     monkeypatch.setattr(mm, "start_dreaming", MagicMock())
     stop_dream = MagicMock()
@@ -74,7 +74,7 @@ def test_idle_period_transitions(monkeypatch):
     mm = MemoryManager(db_path=":memory:")
     times = iter([0, 6, 11, 12, 13])
     monkeypatch.setattr(time, "monotonic", lambda: next(times))
-    scheduler = CognitiveScheduler(mm, T_think=5, T_dream=10, T_alarm=60)
+    scheduler = CognitiveScheduler(mm, T_think=5, T_dream=10, T_alarm=60, think_interval=2)
 
     start_think = MagicMock()
     start_dream = MagicMock()
@@ -88,7 +88,7 @@ def test_idle_period_transitions(monkeypatch):
     scheduler.check()
     assert scheduler.current_state() is CognitiveState.REFLECTIVE
     start_think.assert_called_once()
-    assert start_think.call_args.kwargs.get("interval") == 5
+    assert start_think.call_args.kwargs.get("think_interval") == 2
     assert start_think.call_args.kwargs.get("duration") == 5
 
     scheduler.check()
@@ -110,7 +110,7 @@ def test_thinking_runs_full_duration(monkeypatch):
     mm = MemoryManager(db_path=":memory:")
     times = iter([0, 11, 15, 21])
     monkeypatch.setattr(time, "monotonic", lambda: next(times))
-    sched = CognitiveScheduler(mm, T_think=10, T_dream=12, T_alarm=60)
+    sched = CognitiveScheduler(mm, T_think=10, T_dream=12, T_alarm=60, think_interval=5)
 
     start_think = MagicMock()
     start_dream = MagicMock()

--- a/tests/test_config_reasoning.py
+++ b/tests/test_config_reasoning.py
@@ -19,7 +19,7 @@ def test_start_thinking_uses_reasoning_config(monkeypatch):
 
     manager = MemoryManager(db_path=":memory:")
     with patch.object(ThinkingEngine, "run", return_value=None) as mock_run:
-        manager.start_thinking(interval=1)
+        manager.start_thinking(think_interval=1)
         _, kwargs = mock_run.call_args
         assert kwargs.get("use_reasoning") is True
         assert kwargs.get("reasoning_depth") == 2

--- a/tests/test_dreaming_scheduler.py
+++ b/tests/test_dreaming_scheduler.py
@@ -92,7 +92,7 @@ def test_start_dreaming_stops_thinking():
 
     think_sched = MagicMock(spec=Scheduler)
     with patch.object(ThinkingEngine, "run", return_value=think_sched):
-        manager.start_thinking(interval=1)
+        manager.start_thinking(think_interval=1)
 
     dream_sched = MagicMock(spec=Scheduler)
     with patch.object(DreamEngine, "run", return_value=dream_sched):

--- a/thinking/thinking_engine.py
+++ b/thinking/thinking_engine.py
@@ -109,7 +109,7 @@ class ThinkingEngine:
         self,
         manager: "MemoryManager",
         *,
-        interval: float = 60.0,
+        think_interval: float = 60.0,
         duration: float | None = None,
         llm_name: str = "local",
         use_reasoning: bool = False,
@@ -121,7 +121,7 @@ class ThinkingEngine:
         ----------
         manager:
             Memory manager containing episodic entries.
-        interval:
+        think_interval:
             Seconds between each introspection.
         duration:
             Total runtime in seconds before the scheduler automatically stops.
@@ -141,7 +141,7 @@ class ThinkingEngine:
 
         scheduler = Scheduler()
         now = time.monotonic()
-        manager._next_think_time = now + interval
+        manager._next_think_time = now + think_interval
         if duration is not None:
             manager._think_end_time = now + duration
         else:
@@ -160,11 +160,11 @@ class ThinkingEngine:
                 use_reasoning=use_reasoning,
                 reasoning_depth=reasoning_depth,
             )
-            manager._next_think_time = time.monotonic() + interval
+            manager._next_think_time = time.monotonic() + think_interval
 
-        # run once immediately so a thought occurs even if duration == interval
+        # run once immediately so a thought occurs even if duration == think_interval
         _task()
-        scheduler.schedule(interval, _task)
+        scheduler.schedule(think_interval, _task)
 
         if duration is not None:
             def _stop() -> None:


### PR DESCRIPTION
## Summary
- support repeated thinking intervals via new `think_interval` argument
- keep thinking scheduler using llm_name in `CognitiveScheduler`
- adjust CLI and scheduler logic for new parameter
- update tests for repeated thought generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1c3796ec8322865eb074c377416f