### PR TITLE
Automatically resume reflection after dream phase

### DIFF
--- a/core/cognitive_scheduler.py
+++ b/core/cognitive_scheduler.py
@@ -80,7 +80,11 @@ class CognitiveScheduler:
         return sched
 
     def check(self) -> None:
-        """Evaluate idle time and update cognitive state."""
+        """Evaluate idle time and update cognitive state.
+
+        When waking automatically from sleep, ``last_input`` is adjusted so the
+        next invocation transitions into the reflective state after ``T_think``.
+        """
         now = time.monotonic()
         idle = now - self.last_input
 
@@ -111,7 +115,8 @@ class CognitiveScheduler:
                 if self._dream_sched:
                     self.manager.stop_dreaming()
                     self._dream_sched = None
-                self.last_input = now
+                # Automatically queue the next reflective phase
+                self.last_input = now - self.T_think
                 self.state = CognitiveState.ACTIVE
                 self.state_start = now
 

--- a/tests/test_cognitive_scheduler.py
+++ b/tests/test_cognitive_scheduler.py
@@ -54,7 +54,8 @@ def test_alarm_wakes(monkeypatch):
     monkeypatch.setattr(mm, "start_dreaming", MagicMock())
     stop_dream = MagicMock()
     monkeypatch.setattr(mm, "stop_dreaming", stop_dream)
-    monkeypatch.setattr(mm, "start_thinking", MagicMock())
+    start_think = MagicMock()
+    monkeypatch.setattr(mm, "start_thinking", start_think)
     monkeypatch.setattr(mm, "stop_thinking", MagicMock())
 
     sched.check()
@@ -68,7 +69,8 @@ def test_alarm_wakes(monkeypatch):
     assert stop_dream.called
 
     sched.check()
-    assert sched.current_state() is CognitiveState.ACTIVE
+    assert sched.current_state() is CognitiveState.REFLECTIVE
+    assert start_think.call_count == 2
 
 def test_idle_period_transitions(monkeypatch):
     mm = MemoryManager(db_path=":memory:")


### PR DESCRIPTION
## Summary
- adjust scheduler to queue reflective state after sleep
- expect alarm wake to trigger new thinking session
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1f401a7c8322afdcd2ca511fe539